### PR TITLE
fix python 3 support

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -101,7 +101,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
                 '-v', '%s:/output' % os.path.abspath(output_dir),
                 docker_image,
                 '/bin/bash'],
-            stdin=subprocess.PIPE)
+            stdin=subprocess.PIPE, universal_newlines=True)
 
         docker_process.communicate(bash_script)
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -1,5 +1,9 @@
 from __future__ import print_function
-import os, tempfile, subprocess, urllib2, sys
+import os, tempfile, subprocess, sys
+try:
+    from urllib2 import urlopen
+except ImportError:
+    from urllib.request import urlopen
 from collections import namedtuple
 
 from .util import prepare_command
@@ -10,7 +14,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
     run_with_env = os.path.join(tempfile.gettempdir(), 'appveyor_run_with_env.cmd')
     if not os.path.exists(run_with_env):
         with open(run_with_env, 'wb') as f:
-            request = urllib2.urlopen('https://github.com/ogrisel/python-appveyor-demo/raw/09a1c8672e5015a74d8f69d07add6ee803c176ec/appveyor/run_with_env.cmd')
+            request = urlopen('https://github.com/ogrisel/python-appveyor-demo/raw/09a1c8672e5015a74d8f69d07add6ee803c176ec/appveyor/run_with_env.cmd')
             f.write(request.read())
 
     def shell(args, env=None, cwd=None):


### PR DESCRIPTION
+ urllib2 doesn't exist in python 3 - import from urllib.request instead

+ for linux builds open docker process with universal_newlines; this
  opens a pipe in 'text' mode using the default preferred encoding