### PR TITLE
add a 'pip install' step before building wheels

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -51,7 +51,10 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
                     PATH=$PYBIN:$PATH sh -c {before_build}
                 fi
 
-                "$PYBIN/pip" wheel . -w /tmp/linux_wheels
+                # install the package first to take care of dependencies
+                "$PYBIN/pip" install .
+
+                "$PYBIN/pip" wheel --no-deps . -w /tmp/linux_wheels
             done
 
             for whl in /tmp/linux_wheels/*.whl; do
@@ -66,7 +69,8 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             # Install packages and test
             for PYBIN in {pybin_paths}; do
                 # Install the wheel we just built
-                "$PYBIN/pip" install {package_name} --no-index -f /output
+                "$PYBIN/pip" install {package_name} \
+                    --upgrade --force-reinstall --no-deps --no-index -f /output
 
                 # Install any requirements to run the tests
                 if [ ! -z "{test_requires}" ]; then

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -58,9 +58,12 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             before_build_prepared = prepare_command(before_build, python=python, pip=pip)
             shell(shlex.split(before_build_prepared), env=env)
 
+        # install the package first to take care of dependencies
+        shell([pip, 'install', project_dir], env=env)
+
         # build the wheel to temp dir
         temp_wheel_dir = '/tmp/tmpwheel%s' % config.version
-        shell([pip, 'wheel', project_dir, '-w', temp_wheel_dir], env=env)
+        shell([pip, 'wheel', project_dir, '-w', temp_wheel_dir, '--no-deps'], env=env)
         temp_wheel = glob(temp_wheel_dir+'/*.whl')[0]
 
         if temp_wheel.endswith('none-any.whl'):
@@ -72,8 +75,9 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             # rebuild the wheel with shared libraries included and place in output dir
             shell(['delocate-wheel', '-w', output_dir, temp_wheel], env=env)
 
-        # install the wheel
-        shell([pip, 'install', package_name, '--no-index', '--find-links', output_dir], env=env)
+        # now install the package from the generated wheel
+        shell([pip, 'install', package_name, '--upgrade', '--force-reinstall',
+               '--no-deps', '--no-index', '--find-links', output_dir], env=env)
 
         # test the wheel
         if test_requires:

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -66,11 +66,16 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             before_build_prepared = prepare_command(before_build, python='python', pip='pip')
             shell([before_build_prepared], env=env)
 
+        # install the package first to take care of dependencies
+        shell(['pip', 'install', project_dir], env=env)
+
         # build the wheel
-        shell(['pip', 'wheel', project_dir, '-w', output_dir], env=env)
+        shell(['pip', 'wheel', project_dir, '-w', output_dir, '--no-deps'], env=env)
 
         # install the wheel
-        shell(['pip', 'install', package_name, '--no-index', '-f', output_dir], env=env)
+        shell(['pip', 'install', package_name, '--upgrade',
+               '--force-reinstall', '--no-deps', '--no-index', '-f',
+               output_dir], env=env)
 
         # test the wheel
         if test_requires:


### PR DESCRIPTION
This commit makes 3 changes for builds on all platforms:

1) pip install of the package before the `pip wheel` command
2) add `--no-deps` to the `pip wheel` command since (1) already installs dependencies. This also avoids the additional step of building wheels for dependencies (which was the previous behavior)
3) add `--upgrade --force-reinstall --no-deps` to the pip install comand after pip wheel. This makes sure that the build still tests installing from the built wheel (which is consistent with previous behavior).