### PR TITLE
Solving problems in OS X when library has dependencies

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -59,9 +59,6 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
                     PATH=$PYBIN:$PATH sh -c {before_build}
                 fi
 
-                # install the package first to take care of dependencies
-                "$PYBIN/pip" install .
-
                 "$PYBIN/pip" wheel --no-deps . -w /tmp/linux_wheels
             done
 
@@ -77,8 +74,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             # Install packages and test
             for PYBIN in {pybin_paths}; do
                 # Install the wheel we just built
-                "$PYBIN/pip" install {package_name} \
-                    --upgrade --force-reinstall --no-deps --no-index -f /output
+                "$PYBIN/pip" install {package_name} --upgrade --force-reinstall -f /output
 
                 # Install any requirements to run the tests
                 if [ ! -z "{test_requires}" ]; then

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -58,9 +58,6 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             before_build_prepared = prepare_command(before_build, python=python, pip=pip)
             shell(shlex.split(before_build_prepared), env=env)
 
-        # install the package first to take care of dependencies
-        shell([pip, 'install', project_dir], env=env)
-
         # build the wheel to temp dir
         temp_wheel_dir = '/tmp/tmpwheel%s' % config.version
         shell([pip, 'wheel', project_dir, '-w', temp_wheel_dir, '--no-deps'], env=env)
@@ -76,8 +73,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             shell(['delocate-wheel', '-w', output_dir, temp_wheel], env=env)
 
         # now install the package from the generated wheel
-        shell([pip, 'install', package_name, '--upgrade', '--force-reinstall',
-               '--no-deps', '--no-index', '--find-links', output_dir], env=env)
+        shell([pip, 'install', package_name, '--upgrade', '--force-reinstall', '-f', output_dir], env=env)
 
         # test the wheel
         if test_requires:

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -66,16 +66,11 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             before_build_prepared = prepare_command(before_build, python='python', pip='pip')
             shell([before_build_prepared], env=env)
 
-        # install the package first to take care of dependencies
-        shell(['pip', 'install', project_dir], env=env)
-
         # build the wheel
         shell(['pip', 'wheel', project_dir, '-w', output_dir, '--no-deps'], env=env)
 
         # install the wheel
-        shell(['pip', 'install', package_name, '--upgrade',
-               '--force-reinstall', '--no-deps', '--no-index', '-f',
-               output_dir], env=env)
+        shell(['pip', 'install', package_name, '--upgrade', '--force-reinstall', '-f', output_dir], env=env)
 
         # test the wheel
         if test_requires:


### PR DESCRIPTION
I ran into problems when I tried using `cibuildwheel` on Travis CI's OS X, because my library depends on another wheel from the PyPI (`numpy`, in this case). (In particular in the final `install`step, since it could not find the wheel of my library it had just built.)

Looking into the code, I figured the problem was [the line](https://github.com/joerick/cibuildwheel/blob/083ece8bbc22b014bc766f4162dabbe765643b60/cibuildwheel/macos.py#L64) that says `temp_wheel = glob(temp_wheel_dir+'/*.whl')[0]` and thus basically ignores that `pip wheel .` will by default download the wheels on which the library depends.

This PR simply solves that by not downloading those dependencies until the actual `install` step. However, I'm not sure this is the very best solution and I am not an expert on `setuptools` and `pip`, so maybe there are other possibilities to consider... ?