### PR TITLE
minor fixes including python3 fix

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -77,7 +77,8 @@ def main():
 
     try:
         project_setup_py = os.path.join(project_dir, 'setup.py')
-        name_output = subprocess.check_output([sys.executable, project_setup_py, '--name'])
+        name_output = subprocess.check_output([sys.executable, project_setup_py, '--name'],
+                                              universal_newlines=True)
         # the last line of output is the name
         package_name = name_output.strip().splitlines()[-1]
     except subprocess.CalledProcessError as err:

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -46,6 +46,8 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
 
     for platform_tag, docker_image in platforms:
         platform_configs = [c for c in python_configurations if c.identifier.endswith(platform_tag)]
+        if not platform_configs:
+            continue
 
         bash_script = '''
             set -o errexit
@@ -113,7 +115,11 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
                 '/bin/bash'],
             stdin=subprocess.PIPE, universal_newlines=True)
 
-        docker_process.communicate(bash_script)
+        try:
+            docker_process.communicate(bash_script)
+        except KeyboardInterrupt:
+            docker_process.kill()
+            docker_process.wait()
 
         if docker_process.returncode != 0:
             exit(1)


### PR DESCRIPTION
+ In linux environment, if there was no matching python configurations for a
  particular architecture (i.e. if that architecture was skipped) the docker
  build script would just crash. The offending line:

    for whl in /tmp/linux_wheels/*.whl; do

  would result in whl being equal to the unexpanded glob expression. Rather
  than checking this in the bash script, python checks whether there are any
  actual wheels to build and skips the script if there are none.

+ added universal_newlines=True when making the call to grab the package name -
  this fix is required for python3 since other a bytes prefix (b'') will be
  added to the package name

+ In the linux/docker environment, added a try/catch statement around the
  docker script for KeyboardInterrupt that will kill the docker subprocess in
  cases where cibuildwheel is being run interactively.