### PR TITLE
Allowing CIBW_BEFORE_BUILD to modify the shell environment of pip wheel

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -55,14 +55,15 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             cd /project
 
             for PYBIN in {pybin_paths}; do
-                if [ ! -z {before_build} ]; then
-                    PATH=$PYBIN:$PATH sh -c {before_build}
-                fi
+                # Put quoted string in 'ordinary' environment variable
+                CIBW_BEFORE_BUILD_={before_build}
 
-                # install the package first to take care of dependencies
-                "$PYBIN/pip" install .
+                PATH=$PYBIN:$PATH sh -c "$CIBW_BEFORE_BUILD_
 
-                "$PYBIN/pip" wheel --no-deps . -w /tmp/linux_wheels
+                    # install the package first to take care of dependencies
+                    pip install .
+
+                    pip wheel --no-deps . -w /tmp/linux_wheels"
             done
 
             for whl in /tmp/linux_wheels/*.whl; do

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -112,6 +112,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
                 '-i',
                 '-v', '%s:/project' % os.path.abspath(project_dir),
                 '-v', '%s:/output' % os.path.abspath(output_dir),
+                '-v', '/:/host',
                 docker_image,
                 '/bin/bash'],
             stdin=subprocess.PIPE, universal_newlines=True)


### PR DESCRIPTION
This is one way #16 could be solved (and which could also solve #13).


Based on @tgarc's suggestion:

> And if the sh -c was removed, would that allow you to do what you wanted?

I basically prepended the content of `CIBW_BEFORE_BUILD` to the `pip` commands, such that they are all evaluated in a `sh -c`. Consequently, the cibuildwheel user could set environment variables, change directory, or do anything else, and this wíll affect the `pip wheel` but won't affect any of the following commands.

Just one path of the many solutions that might work, but this one seems to stick quite close to the original plan, as far as I can tell.
Any thoughts, remarks, complaints?