### PR TITLE
revert PR9; add --no-deps to pip wheel; address PR11

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -107,6 +107,9 @@ def main():
 
     print_preamble(platform, build_options)
 
+    if not os.path.exists(output_dir):
+        os.mkdir(output_dir)
+
     if platform == 'linux':
         cibuildwheel.linux.build(**build_options)
     elif platform == 'windows':


### PR DESCRIPTION
This is a WIP - there will be some tweaking but the proof of concept is there and should be fully functional. I've tested this with my package on all platforms. This should address the issue raised by PR #11 without needed an additional pip pre-install step. It also removes the step of building wheels for dependencies - a step which adds extra build time and may even cause issues for some packages. BTW this follows more closely the build steps in the https://github.com/matthew-brett/multibuild project.

Revert PR9; it was never actually needed in the first place it just fixed an
issue by side effect.

1) add --no-deps to pip wheel step in order to avoid building wheels for
   dependencies. This also addresses the issues raised in PR #11.

2) Modify the pip install step across platforms to allow installation of
   dependencies from the index. (This is required since we will no longer be
   building wheels for dependencies).