### PR TITLE
Unbuffered stdout for Windows and displaying the output of subprocess calls

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
 build_script:
   - pip install .
-  - python ./run_tests.py
+  # the '-u' flag is required so the output is in the correct order. 
+  # See https://github.com/joerick/cibuildwheel/pull/24 for more info.
+  - python -u ./run_tests.py

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -136,6 +136,7 @@ def print_preamble(platform, build_options):
         print('  %s: %r' % (option, value))
 
     print('\nHere we go!\n')
+    sys.stdout.flush()
 
 if __name__ == '__main__':
     main()

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -136,7 +136,6 @@ def print_preamble(platform, build_options):
         print('  %s: %r' % (option, value))
 
     print('\nHere we go!\n')
-    sys.stdout.flush()
 
 if __name__ == '__main__':
     main()

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -11,6 +11,9 @@ from .util import prepare_command
 
 
 def build(project_dir, package_name, output_dir, test_command, test_requires, before_build, skip):
+    # Python under AppVeyor/Windows seems to be buffering by default, giving problems interleaving subprocess call output with unflushed calls to 'print'
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+
     # run_with_env is a cmd file that sets the right environment variables to
     run_with_env = os.path.join(tempfile.gettempdir(), 'appveyor_run_with_env.cmd')
     if not os.path.exists(run_with_env):
@@ -22,7 +25,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         # print the command executing for the logs
         print('+ ' + ' '.join(args))
         args = ['cmd', '/E:ON', '/V:ON', '/C', run_with_env] + args
-        return subprocess.check_output(' '.join(args), env=env, cwd=cwd)
+        return subprocess.check_call(' '.join(args), env=env, cwd=cwd)
 
     PythonConfiguration = namedtuple('PythonConfiguration', ['version', 'arch', 'identifier', 'path'])
     python_configurations = [

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -12,6 +12,7 @@ from .util import prepare_command
 
 def build(project_dir, package_name, output_dir, test_command, test_requires, before_build, skip):
     # Python under AppVeyor/Windows seems to be buffering by default, giving problems interleaving subprocess call output with unflushed calls to 'print'
+    sys.stdout.flush()
     sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
 
     # run_with_env is a cmd file that sets the right environment variables to


### PR DESCRIPTION
Cfr. side issue in #15:
- Forcing Python on Windows to not buffer its stdout, such that the output of cibuildwheel and that of its subprocess calls is nicely interleaved.
- Changing `subprocess.check_output` to `check_call` such that the stdout of these calls is not swallowed into a never-printed string by cibuildwheel.

