### PR TITLE
use os.makedirs to allow nested output directory

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -108,7 +108,7 @@ def main():
     print_preamble(platform, build_options)
 
     if not os.path.exists(output_dir):
-        os.mkdir(output_dir)
+        os.makedirs(output_dir)
 
     if platform == 'linux':
         cibuildwheel.linux.build(**build_options)


### PR DESCRIPTION
As the title says. Reasoning for this it to e.g. have an output directory of `wheelhouse/${TRAVIS_TAG}`.

Not sure how to test this, any pointers are welcome :)