### PR TITLE
Adding an overview of available options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ All being well, you should get wheels delivered to you in a few minutes.
 
 > ⚠️ Got an error? Check the [checklist](#it-didnt-work) below.
 
+### Configuration overview
+
+`cibuildwheel` allows for easy customization of the various phases of the build process demonstrated above:
+
+|   | Option |   |
+|---|---|---|
+| **Target wheels** | `CIBW_PLATFORM` | Override the auto-detected target platform |
+|   | `CIBW_SKIP` | Skip certain Python versions |
+| **Build environment** | `CIBW_ENVIRONMENT` | Set environment variables needed during the build |
+|   | `CIBW_BEFORE_BUILD` | Execute a shell command preparing each wheel's build |
+| **Tests** | `CIBW_TEST_COMMAND` | Execute a shell command to test all built wheels |
+|   | `CIBW_TEST_REQUIRES` | Install Python dependencies before running the tests |
+
+A more detailed description of the options, the allowed values, and some examples can be found in the [Options](#options) section.
+
 
 Options
 -------


### PR DESCRIPTION
Added a short overview of the options cibuildwheel offers. (As proposed in #21.)

I wondered where to put it, at the start of the Options section or at the end of the Usage one. In the end I went for the latter, since after reading the 'quick start example', potential users might be wondering what is available to adapt cibuildwheel to their needs. This table then would them an idea of the kind of customizations that are provided, before actually diving into the more detailed documentation per configuration.