### PR TITLE
Adding extra mount / to /host on docker invocation for linux wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ All being well, you should get wheels delivered to you in a few minutes.
 
 A more detailed description of the options, the allowed values, and some examples can be found in the [Options](#options) section.
 
+### Linux builds on Docker
+
+Linux wheels are built in the [`manylinux1` docker images](https://github.com/pypa/manylinux) to provide binary compatible wheels on linux, according to [PEP 513](https://www.python.org/dev/peps/pep-0513/). Because of this, when building with `cibuildwheel` on Linux, a few things should be taken into account:
+- Progams and libraries cannot be installed on the Travis CI Ubuntu host with `apt-get`, but can be installed inside of the Docker image using `yum` or manually. The same goes for environment variables that are potentially needed to customize the wheel building. `cibuildwheel` supports this by providing the `CIBW_ENVIRONMENT` and `CIBW_BEFORE_BUILD` options to setup the build environment inside the running Docker image. See [below](#options) for details on these options.
+- The project directory is mounted in the running Docker instance as `/project`, the output directory for the wheels as `/output`. In general, this handled transparently by `cibuildwheel`. For a more finegrained level of control however, the root of the host file system is mounted as `/host`, allowing for example to access shared files, caches, etc. on the host file system.
+
 
 Options
 -------

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ A more detailed description of the options, the allowed values, and some example
 
 ### Linux builds on Docker
 
-Linux wheels are built in the [`manylinux1` docker images](https://github.com/pypa/manylinux) to provide binary compatible wheels on linux, according to [PEP 513](https://www.python.org/dev/peps/pep-0513/). Because of this, when building with `cibuildwheel` on Linux, a few things should be taken into account:
+Linux wheels are built in the [`manylinux1` docker images](https://github.com/pypa/manylinux) to provide binary compatible wheels on Linux, according to [PEP 513](https://www.python.org/dev/peps/pep-0513/). Because of this, when building with `cibuildwheel` on Linux, a few things should be taken into account:
 - Progams and libraries cannot be installed on the Travis CI Ubuntu host with `apt-get`, but can be installed inside of the Docker image using `yum` or manually. The same goes for environment variables that are potentially needed to customize the wheel building. `cibuildwheel` supports this by providing the `CIBW_ENVIRONMENT` and `CIBW_BEFORE_BUILD` options to setup the build environment inside the running Docker image. See [below](#options) for details on these options.
-- The project directory is mounted in the running Docker instance as `/project`, the output directory for the wheels as `/output`. In general, this handled transparently by `cibuildwheel`. For a more finegrained level of control however, the root of the host file system is mounted as `/host`, allowing for example to access shared files, caches, etc. on the host file system.
+- The project directory is mounted in the running Docker instance as `/project`, the output directory for the wheels as `/output`. In general, this is handled transparently by `cibuildwheel`. For a more finegrained level of control however, the root of the host file system is mounted as `/host`, allowing for example to access shared files, caches, etc. on the host file system.
 
 
 Options

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -120,6 +120,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
                 '-i',
                 '-v', '%s:/project' % os.path.abspath(project_dir),
                 '-v', '%s:/output' % os.path.abspath(output_dir),
+                '-v', '/:/host',
                 docker_image,
                 '/bin/bash'],
             stdin=subprocess.PIPE, universal_newlines=True)


### PR DESCRIPTION
Under the assumption that https://travis-ci.org/YannickJadoul/Parselmouth/jobs/275233309 succeeds, a sillily small PR, mounting the root of the Travis CI/host file system as `/host` in the docker image for Linux builds. This allows to access directories outside of the project folder to be accessed inside of docker (e.g. the `ccache` dir that is saved/restored, in my specific use case), without big hacks (such as hard-linking that directory inside of the project root folder, or who knows what other tricks there would be).

If accepted, I still need to add some documentation in the README, perhaps.