### PR TITLE
add bashlex to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,7 @@ setup(
             'cibuildwheel = cibuildwheel.__main__:main',
         ],
     },
+    install_requires=[
+        'bashlex',
+    ],
 )


### PR DESCRIPTION
bashlex was missing from the setup.py dependencies (which causes pip install to fail). Seems like testing should've caught this. I'm confused how this didn't come up in the travis tests.