### PR TITLE
Support for CIBW_SKIP platform specific variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ Example: `cp27-macosx_10_6_intel`  (don't build on Python 2 on Mac)
 Example: `cp27-win*`  (don't build on Python 2.7 on Windows)  
 Example: `cp34-* cp35-*`  (don't build on Python 3.4 or Python 3.5)  
 
+Platform-specific variants also available:
+`CIBW_SKIP_MACOS` | `CIBW_SKIP_WINDOWS` | `CIBW_SKIP_LINUX`
+
 | Environment variable: `CIBW_ENVIRONMENT`
 | ---
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A more detailed description of the options, the allowed values, and some example
 ### Linux builds on Docker
 
 Linux wheels are built in the [`manylinux1` docker images](https://github.com/pypa/manylinux) to provide binary compatible wheels on Linux, according to [PEP 513](https://www.python.org/dev/peps/pep-0513/). Because of this, when building with `cibuildwheel` on Linux, a few things should be taken into account:
-- Progams and libraries cannot be installed on the Travis CI Ubuntu host with `apt-get`, but can be installed inside of the Docker image using `yum` or manually. The same goes for environment variables that are potentially needed to customize the wheel building. `cibuildwheel` supports this by providing the `CIBW_ENVIRONMENT` and `CIBW_BEFORE_BUILD` options to setup the build environment inside the running Docker image. See [below](#options) for details on these options.
+- Programs and libraries cannot be installed on the Travis CI Ubuntu host with `apt-get`, but can be installed inside of the Docker image using `yum` or manually. The same goes for environment variables that are potentially needed to customize the wheel building. `cibuildwheel` supports this by providing the `CIBW_ENVIRONMENT` and `CIBW_BEFORE_BUILD` options to setup the build environment inside the running Docker image. See [below](#options) for details on these options.
 - The project directory is mounted in the running Docker instance as `/project`, the output directory for the wheels as `/output`. In general, this is handled transparently by `cibuildwheel`. For a more finegrained level of control however, the root of the host file system is mounted as `/host`, allowing for example to access shared files, caches, etc. on the host file system.
 
 

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -74,7 +74,7 @@ def main():
     test_requires = os.environ.get('CIBW_TEST_REQUIRES', '').split()
     project_dir = args.project_dir
     before_build = get_option_from_environment('CIBW_BEFORE_BUILD', platform=platform)
-    skip_config = os.environ.get('CIBW_SKIP', '')
+    skip_config = get_option_from_environment('CIBW_SKIP', platform=platform) or ''
     environment_config = get_option_from_environment('CIBW_ENVIRONMENT', platform=platform) or ''
 
     try:


### PR DESCRIPTION
To workaround a still mysterious problem building Py3.6 binary wheel on Travis CI for a C++ project I'm maintaining, I need a way to say "don't build Py36 wheel for GNU/Linux, but do that on other systems".

This adds `CIBW_SKIP_<platform>` variants, as done for other variables.