### PR TITLE
Fixing 'Minimal setup' in README to have `python -m pip` instead of `pip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usage
         - os: osx
 
     script:
-      - pip install cibuildwheel==0.6.0
+      - python -m pip install cibuildwheel==0.6.0
       - cibuildwheel --output-dir wheelhouse
     ```
 


### PR DESCRIPTION
Cfr. #48