### PR TITLE
macOS update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - "PYTHON=python3"
       before_install:
         - brew update
-        - brew install python3
+        - brew outdated python || brew upgrade python
 
 script:
   - |

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -18,6 +18,8 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         PythonConfiguration(version='3.5', identifier='cp35-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg'),
         PythonConfiguration(version='3.6', identifier='cp36-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.6.5/python-3.6.5-macosx10.6.pkg'),
     ]
+    get_pip_url = 'https://bootstrap.pypa.io/get-pip.py'
+    get_pip_script = '/tmp/get-pip.py'
 
     pkgs_output = subprocess.check_output(['pkgutil',  '--pkgs'])
     if sys.version_info[0] >= 3:
@@ -34,6 +36,9 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         return subprocess.check_call(args, env=env, cwd=cwd, shell=shell)
 
     abs_project_dir = os.path.abspath(project_dir)
+
+    # get latest pip once and for all
+    call(['curl', '-L', '-o', get_pip_script, get_pip_url])
 
     for config in python_configurations:
         if skip(config.identifier):
@@ -63,7 +68,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         call([python, '--version'], env=env)
 
         # install pip & wheel
-        call([python, '-m', 'ensurepip', '--upgrade'], env=env)
+        call([python, get_pip_script, '--no-setuptools', '--no-wheel'], env=env)
         call([pip, '--version'], env=env)
         call([pip, 'install', 'wheel'], env=env)
         call([pip, 'install', 'delocate'], env=env)

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -13,10 +13,10 @@ from .util import prepare_command
 def build(project_dir, package_name, output_dir, test_command, test_requires, before_build, skip, environment):
     PythonConfiguration = namedtuple('PythonConfiguration', ['version', 'identifier', 'url'])
     python_configurations = [
-        PythonConfiguration(version='2.7', identifier='cp27-macosx_10_6_intel', url='https://www.python.org/ftp/python/2.7.13/python-2.7.13-macosx10.6.pkg'),
+        PythonConfiguration(version='2.7', identifier='cp27-macosx_10_6_intel', url='https://www.python.org/ftp/python/2.7.14/python-2.7.14-macosx10.6.pkg'),
         PythonConfiguration(version='3.4', identifier='cp34-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.4.4/python-3.4.4-macosx10.6.pkg'),
-        PythonConfiguration(version='3.5', identifier='cp35-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.5.3/python-3.5.3-macosx10.6.pkg'),
-        PythonConfiguration(version='3.6', identifier='cp36-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.6.0/python-3.6.0-macosx10.6.pkg'),
+        PythonConfiguration(version='3.5', identifier='cp35-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg'),
+        PythonConfiguration(version='3.6', identifier='cp36-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.6.5/python-3.6.5-macosx10.6.pkg'),
     ]
 
     pkgs_output = subprocess.check_output(['pkgutil',  '--pkgs'])


### PR DESCRIPTION
This PR does the following things:
- fix python3 test on macOS:
   brew python formula has been updated for pyhton3, c.f. https://travis-ci.org/mayeut/cibuildwheel/builds/360577716 macOS python3 errored build
- Update python versions used to build wheels (latest binaries)
- Use latest pip:
   With the new PyPI stuff on-going, pip is failing with required TLS 1.2, c.f. https://travis-ci.org/mayeut/cibuildwheel/builds/360577716 macOS python2 failing build
   The job has been started in the brownout window enforcing TLS 1.2, c.f. pypa/warehouse#3411
   pip 9.0.2 has been updated to support TLS 1.2 on macOS (where openSSL is too old) in pypa/pip#4454