### PR TITLE
Replacing {python} and {pip} in CIBW_TEST_COMMAND (and {project} in C…

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ A shell command to run before building the wheel. This option allows you to run 
 
 If dependencies are required to build your wheel (for example if you include a header from a Python module), set this to `{pip} install .`, and the dependencies will be installed automatically by pip. However, this means your package will be built twice - if your package takes a long time to build, you might wish to manually list the dependencies here instead.
 
-The active Python binary can be accessed using `{python}`, and pip with `{pip}`. These are useful when you need to write `python3` or `pip3` on a Python 3.x build.
+The active Python binary can be accessed using `{python}`, and pip with `{pip}`. These are useful when you need to write `python3` or `pip3` on a Python 3.x build. `{project}` can be used as a placeholder for the absolute path to the project's root.
 
 Example: `{pip} install .`  
 Example: `{pip} install pybind11`  
@@ -222,7 +222,7 @@ Example: `dockcross/manylinux-x86`
 
 Optional.
 
-Shell command to run tests after the build. The wheel will be installed automatically and available for import from the tests. The project root should be included in the command as "{project}".
+Shell command to run tests after the build. The wheel will be installed automatically and available for import from the tests. Just like in the `CIBW_BEFORE_BUILD` option, `{python}`, `{pip}`, and `{project}` will respectively be replaced by the Python executable, the pip executable, and the absolute project directory.
 
 Example: `nosetests {project}/tests`
 

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -103,7 +103,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             pybin_paths=' '.join(c.path+'/bin' for c in platform_configs),
             test_requires=' '.join(test_requires),
             test_command=shlex_quote(
-                test_command.format(python='python', pip='pip', project='/project') if test_command else ''
+                prepare_command(test_command, python='python', pip='pip', project='/project') if test_command else ''
             ),
             before_build=shlex_quote(
                 prepare_command(before_build, python='python', pip='pip', project='/project') if before_build else ''

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -103,10 +103,10 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             pybin_paths=' '.join(c.path+'/bin' for c in platform_configs),
             test_requires=' '.join(test_requires),
             test_command=shlex_quote(
-                test_command.format(project='/project') if test_command else ''
+                test_command.format(python='python', pip='pip', project='/project') if test_command else ''
             ),
             before_build=shlex_quote(
-                prepare_command(before_build, python='python', pip='pip') if before_build else ''
+                prepare_command(before_build, python='python', pip='pip', project='/project') if before_build else ''
             ),
             environment_exports='\n'.join(environment.as_shell_commands()),
         )

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -83,7 +83,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
 
         # run the before_build command
         if before_build:
-            before_build_prepared = prepare_command(before_build, python=python, pip=pip)
+            before_build_prepared = prepare_command(before_build, python=python, pip=pip, project=abs_project_dir)
             call(before_build_prepared, env=env, shell=True)
 
         # build the wheel
@@ -110,8 +110,8 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             # run the tests from $HOME, with an absolute path in the command
             # (this ensures that Python runs the tests against the installed wheel
             # and not the repo code)
-            test_command_absolute = test_command.format(project=abs_project_dir)
-            call(shlex.split(test_command_absolute), cwd=os.environ['HOME'], env=env)
+            test_command_prepared = prepare_command(test_command, python=python, pip=pip, project=abs_project_dir)
+            call(shlex.split(test_command_prepared), cwd=os.environ['HOME'], env=env)
 
         # we're all done here; move it to output
         shutil.move(delocated_wheel, output_dir)

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -1,7 +1,7 @@
 from fnmatch import fnmatch
 
 
-def prepare_command(command, python, pip):
+def prepare_command(command, python, pip, project):
     '''
     Preprocesses a command by expanding variables like {python} or {pip}.
 
@@ -10,7 +10,7 @@ def prepare_command(command, python, pip):
     Python 3, the user could write `{python} setup.py test`. This command would expand
     it out to python2 or python3 as appropriate.
     '''
-    return command.format(python=python, pip=pip)
+    return command.format(python=python, pip=pip, project=project)
 
 
 class BuildSkipper(object):

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -78,7 +78,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
 
         # run the before_build command
         if before_build:
-            before_build_prepared = prepare_command(before_build, python='python', pip='pip')
+            before_build_prepared = prepare_command(before_build, python='python', pip='pip', project=abs_project_dir)
             shell([before_build_prepared], env=env)
 
         # build the wheel
@@ -95,8 +95,8 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             # run the tests from c:\, with an absolute path in the command
             # (this ensures that Python runs the tests against the installed wheel
             # and not the repo code)
-            test_command_absolute = test_command.format(project=abs_project_dir)
-            shell([test_command_absolute], cwd='c:\\', env=env)
+            test_command_prepared = prepare_command(test_command, python='python', pip='pip', project=abs_project_dir)
+            shell([test_command_prepared], cwd='c:\\', env=env)
 
         # we're all done here; move it to output
         shutil.move(built_wheel, output_dir)


### PR DESCRIPTION
Increasing consistency and attending to #56.

A note on the commit and a general remark:

- Note: Python's `format` does not allow for partial formatting and replacement of `{project}` was already done for `CIBW_TEST_COMMAND` (so I could not run `util.prepare_command` before or after that other `format` call). So I added `project` into `prepare_command` (and consequently added the possibility to use `{project}` in `CIBW_BEFORE_BUILD`. Documented in the README in this PR.
- Remark: Is there a fundamental reason that we have to have this `{python}` and `{pip}` replacement? I can see this being replaced by something else than `python` and `pip` only on OS X, and it's not an absolute path there, either. If we get the `PATH` right (and we do), don't all Python distributions provide a (symbolic) link called `python` and `pip` to the right executable?