### PR TITLE
windows: upgrade pip with 'python -m pip'

### DIFF
--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -72,7 +72,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         shell(['python', '-c', '"import struct; print(struct.calcsize(\'P\') * 8)\"'], env=env)
 
         # prepare the Python environment
-        shell(['pip', 'install', '--disable-pip-version-check', '--user', '--upgrade', 'pip'],
+        shell(['python', '-m', 'pip', 'install', '--upgrade', 'pip'],
               env=env)
         shell(['pip', 'install', 'wheel'], env=env)
 


### PR DESCRIPTION
this fixes an "ImportError: cannot import name main" when self-upgrading pip to latest version 10: https://github.com/pypa/pip/issues/5240#issuecomment-382989420

Before applying this patch, I was getting this error:
https://ci.appveyor.com/project/trufont/uharfbuzz/build/1.0.4#L91

After applying this patch (and pip installing from my cibuildwheel fork), the pip self-upgrade works and the build succeeds:
https://ci.appveyor.com/project/trufont/uharfbuzz/build/1.0.7