### PR TITLE
Give ownership of the wheel files to the current user instead of root on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,42 +5,28 @@ matrix:
     # Linux Python 2
     - sudo: required
       language: python
-      services:
-        - docker
-      env:
-        - "PYTHON=python2"
+      python: 2.7
+      services: docker
+      env: PYTHON=python
 
     # Linux Python 3
     - sudo: required
       language: python
-      services:
-        - docker
-      env:
-        - "PYTHON=python3"
-      before_install:
-        - sudo apt-get -qq update
-        - sudo apt-get install -y python3-pip
+      python: 3.4
+      services: docker
+      env: PYTHON=python
 
     # macOS Python 2
     - os: osx
-      env:
-        - "PYTHON=python2"
+      env: PYTHON=python2
 
     # macOS Python 3
     - os: osx
-      env:
-        - "PYTHON=python3"
+      env: PYTHON=python3
       before_install:
         - brew update
         - brew outdated python || brew upgrade python
 
-script:
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      $PYTHON -m pip install -r requirements-dev.txt
-      $PYTHON ./bin/run_tests.py
-    else
-      # linux test requires root to clean up the wheelhouse (docker runs as root)
-      sudo $PYTHON -m pip install -r requirements-dev.txt
-      sudo $PYTHON ./bin/run_tests.py
-    fi
+install: $PYTHON -m pip install -r requirements-dev.txt
+
+script: $PYTHON ./bin/run_tests.py

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -95,6 +95,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
 
                 # we're all done here; move it to output
                 mv "$delocated_wheel" /output
+                chown {uid}:{gid} "/output/$(basename "$delocated_wheel")"
             done
         '''.format(
             package_name=package_name,
@@ -108,6 +109,8 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             ),
             build_verbosity_flag=' '.join(get_build_verbosity_extra_flags(build_verbosity)),
             environment_exports='\n'.join(environment.as_shell_commands()),
+            uid=os.getuid(),
+            gid=os.getgid(),
         )
 
         docker_process = subprocess.Popen([


### PR DESCRIPTION
Give ownership of the wheel files to the current user instead of root on Linux, this also allows to cleanup the `.travis.yml` file a bit. 
