### PR TITLE
macOS/Windows: Update setuptools

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -70,6 +70,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         # install pip & wheel
         call([python, get_pip_script, '--no-setuptools', '--no-wheel'], env=env)
         call([pip, '--version'], env=env)
+        call([pip, 'install', '--upgrade', 'setuptools'], env=env)
         call([pip, 'install', 'wheel'], env=env)
         call([pip, 'install', 'delocate'], env=env)
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -74,6 +74,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         # prepare the Python environment
         shell(['python', '-m', 'pip', 'install', '--upgrade', 'pip'],
               env=env)
+        shell(['pip', 'install', '--upgrade', 'setuptools'], env=env)
         shell(['pip', 'install', 'wheel'], env=env)
 
         # run the before_build command


### PR DESCRIPTION
Update setuptools on macOS/Windows
Not required on linux since the manylinux image is updated frequently

It might help with the issue seen in #63 