### PR TITLE
Add support for Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Space-separated list of builds to skip. Each build has an identifier like `cp27-
 
 The format is `python_tag-platform_tag`. The tags are as defined in [PEP 0425](https://www.python.org/dev/peps/pep-0425/#details).
 
-Python tags look like `cp27` `cp34` `cp35` `cp36`
+Python tags look like `cp27` `cp34` `cp35` `cp36` `cp37`
 
 Platform tags look like `macosx_10_6_intel` `manylinux1_x86_64` `manylinux1_i686` `win32` `win_amd64`
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ What does it do?
 | Python 3.4 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Python 3.5 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Python 3.6 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Python 3.7 | ✅ | ✅ | ✅ |    |    |
 
 - Builds manylinux, macOS and Windows (32 and 64bit) wheels using Travis CI and Appveyor
 - Bundles shared library dependencies on Linux and macOS through [auditwheel](https://github.com/pypa/auditwheel) and [delocate](https://github.com/matthew-brett/delocate)

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -25,11 +25,13 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         PythonConfiguration(identifier='cp34-manylinux1_x86_64', path='/opt/python/cp34-cp34m'),
         PythonConfiguration(identifier='cp35-manylinux1_x86_64', path='/opt/python/cp35-cp35m'),
         PythonConfiguration(identifier='cp36-manylinux1_x86_64', path='/opt/python/cp36-cp36m'),
+        PythonConfiguration(identifier='cp37-manylinux1_x86_64', path='/opt/python/cp37-cp37m'),
         PythonConfiguration(identifier='cp27-manylinux1_i686', path='/opt/python/cp27-cp27m'),
         PythonConfiguration(identifier='cp27-manylinux1_i686', path='/opt/python/cp27-cp27mu'),
         PythonConfiguration(identifier='cp34-manylinux1_i686', path='/opt/python/cp34-cp34m'),
         PythonConfiguration(identifier='cp35-manylinux1_i686', path='/opt/python/cp35-cp35m'),
         PythonConfiguration(identifier='cp36-manylinux1_i686', path='/opt/python/cp36-cp36m'),
+        PythonConfiguration(identifier='cp37-manylinux1_i686', path='/opt/python/cp37-cp36m'),
     ]
 
     # skip builds as required

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -31,7 +31,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         PythonConfiguration(identifier='cp34-manylinux1_i686', path='/opt/python/cp34-cp34m'),
         PythonConfiguration(identifier='cp35-manylinux1_i686', path='/opt/python/cp35-cp35m'),
         PythonConfiguration(identifier='cp36-manylinux1_i686', path='/opt/python/cp36-cp36m'),
-        PythonConfiguration(identifier='cp37-manylinux1_i686', path='/opt/python/cp37-cp36m'),
+        PythonConfiguration(identifier='cp37-manylinux1_i686', path='/opt/python/cp37-cp37m'),
     ]
 
     # skip builds as required

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -17,6 +17,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         PythonConfiguration(version='3.4', identifier='cp34-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.4.4/python-3.4.4-macosx10.6.pkg'),
         PythonConfiguration(version='3.5', identifier='cp35-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg'),
         PythonConfiguration(version='3.6', identifier='cp36-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.6.5/python-3.6.5-macosx10.6.pkg'),
+        PythonConfiguration(version='3.7', identifier='cp37-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.7.0/python-3.7.0rc1-macosx10.6.pkg'),
     ]
     get_pip_url = 'https://bootstrap.pypa.io/get-pip.py'
     get_pip_script = '/tmp/get-pip.py'

--- a/test/06_docker_images/environment.json
+++ b/test/06_docker_images/environment.json
@@ -1,4 +1,5 @@
 {
     "CIBW_MANYLINUX1_X86_64_IMAGE": "dockcross/manylinux-x64",
-    "CIBW_MANYLINUX1_I686_IMAGE": "dockcross/manylinux-x86"
+    "CIBW_MANYLINUX1_I686_IMAGE": "dockcross/manylinux-x86",
+    "CIBW_SKIP": "cp37-manylinux*"
 }


### PR DESCRIPTION
This enables building binary wheels for Python 3.7, now at its rc1 release.

It is included in the latest manylinux1 Docker image, see https://github.com/pypa/manylinux/pull/196.

Accordingly to https://www.appveyor.com/docs/build-environment/#python it is not yet available on Appveyor.