### PR TITLE
Add pybase64 to the list of working examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Here are some repos that use cibuildwheel.
 - [websockets](https://github.com/aaugustin/websockets)
 - [Parselmouth](https://github.com/YannickJadoul/Parselmouth)
 - [python-admesh](https://github.com/admesh/python-admesh)
+- [pybase64](https://github.com/mayeut/pybase64)
 
 > Add repo here! Send a PR.
 


### PR DESCRIPTION
Thanks for the great work !

@joerick, `pybase64` uses `pypi deploy plugin` on `travis` which is not documented in `joerick/cibuildwheel-autopypi-example`. `python-admesh` also uses the plugin but does not build for `macOS` using `python3` which requires a trick when deploying with `pypi deploy plugin`
I can create a PR on  `cibuildwheel-autopypi-example` if you're interested in that.