### PR TITLE
Applying unbuffered output to all platforms instead of only Windows

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -4,7 +4,7 @@ import argparse, os, subprocess, sys, textwrap
 import cibuildwheel
 import cibuildwheel.linux, cibuildwheel.windows, cibuildwheel.macos
 from cibuildwheel.environment import parse_environment, EnvironmentParseError
-from cibuildwheel.util import BuildSkipper
+from cibuildwheel.util import BuildSkipper, Unbuffered
 
 def get_option_from_environment(option_name, platform=None, default=None):
     '''
@@ -140,6 +140,9 @@ def main():
         pass
     elif platform == 'windows':
         pass
+
+    # Python is buffering by default when running on the CI platforms, giving problems interleaving subprocess call output with unflushed calls to 'print'
+    sys.stdout = Unbuffered(sys.stdout)
 
     print_preamble(platform, build_options)
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -7,14 +7,10 @@ except ImportError:
 from collections import namedtuple
 from glob import glob
 
-from .util import prepare_command, get_build_verbosity_extra_flags, Unbuffered
+from .util import prepare_command, get_build_verbosity_extra_flags
 
 
 def build(project_dir, package_name, output_dir, test_command, test_requires, before_build, build_verbosity, skip, environment):
-    # Python under AppVeyor/Windows seems to be buffering by default, giving problems interleaving subprocess call output with unflushed calls to 'print'
-    sys.stdout.flush()
-    sys.stdout = Unbuffered(sys.stdout)
-
     # run_with_env is a cmd file that sets the right environment variables to
     run_with_env = os.path.join(tempfile.gettempdir(), 'appveyor_run_with_env.cmd')
     if not os.path.exists(run_with_env):


### PR DESCRIPTION
I have started noticing that the output from `cibuildwheel` on Travis CI is not interleaved well with the output of the subprocesses (just like on Windows/AppVeyor, see #23, #24, #26) in my build: see e.g. https://travis-ci.org/YannickJadoul/Parselmouth/jobs/410930945 (Weirdly enough, this problem does not seem to show up on the CI tests of `cibuildwheel` itself?)

By extending this fix for Windows to all platforms, the problem seems to be fixed: https://travis-ci.org/YannickJadoul/Parselmouth/jobs/411213753