### PR TITLE
Adding CIBW_FROM_PYPI option

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -85,6 +85,7 @@ def main():
     build_verbosity = get_option_from_environment('CIBW_BUILD_VERBOSITY', platform=platform, default='')
     skip_config = os.environ.get('CIBW_SKIP', '')
     environment_config = get_option_from_environment('CIBW_ENVIRONMENT', platform=platform, default='')
+    from_pypi = os.environ.get('CIBW_FROM_PYPI', '')
 
     try:
         build_verbosity = min(3, max(-3, int(build_verbosity)))
@@ -136,6 +137,7 @@ def main():
         build_verbosity=build_verbosity,
         skip=skip,
         environment=environment,
+        from_pypi=from_pypi,
     )
 
     if platform == 'linux':

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -15,7 +15,7 @@ class DockerRunTimeoutError(Exception):
     pass
 
 
-def build(project_dir, package_name, output_dir, test_command, test_requires, before_build, build_verbosity, skip, environment, manylinux1_images):
+def build(project_dir, package_name, output_dir, test_command, test_requires, before_build, build_verbosity, skip, environment, manylinux1_images, from_pypi):
     try:
         subprocess.check_call(['docker', '--version'])
     except:
@@ -80,7 +80,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
                 ls -l /host
 
                 # Build that wheel
-                PATH="$PYBIN:$PATH" "$PYBIN/pip" wheel . -w /tmp/built_wheel --no-deps {build_verbosity_flag}
+                PATH="$PYBIN:$PATH" "$PYBIN/pip" wheel {pypi_or_dir} -w /tmp/built_wheel --no-deps {build_verbosity_flag}
                 built_wheel=(/tmp/built_wheel/*.whl)
 
                 # Delocate the wheel
@@ -125,6 +125,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             ),
             build_verbosity_flag=' '.join(get_build_verbosity_extra_flags(build_verbosity)),
             environment_exports='\n'.join(environment.as_shell_commands()),
+            pypi_or_dir=from_pypi or '.',
             uid=os.getuid(),
             gid=os.getgid(),
         )

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -10,7 +10,7 @@ except ImportError:
 from .util import prepare_command, get_build_verbosity_extra_flags
 
 
-def build(project_dir, package_name, output_dir, test_command, test_requires, before_build, build_verbosity, skip, environment):
+def build(project_dir, package_name, output_dir, test_command, test_requires, before_build, build_verbosity, skip, environment, from_pypi):
     PythonConfiguration = namedtuple('PythonConfiguration', ['version', 'identifier', 'url'])
     python_configurations = [
         PythonConfiguration(version='2.7', identifier='cp27-macosx_10_6_intel', url='https://www.python.org/ftp/python/2.7.15/python-2.7.15-macosx10.6.pkg'),
@@ -104,7 +104,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             call(before_build_prepared, env=env, shell=True)
 
         # build the wheel
-        call(['pip', 'wheel', abs_project_dir, '-w', '/tmp/built_wheel', '--no-deps'] + get_build_verbosity_extra_flags(build_verbosity), env=env)
+        call(['pip', 'wheel', from_pypi or abs_project_dir, '-w', '/tmp/built_wheel', '--no-deps'] + get_build_verbosity_extra_flags(build_verbosity), env=env)
         built_wheel = glob('/tmp/built_wheel/*.whl')[0]
 
         if built_wheel.endswith('none-any.whl'):

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -10,7 +10,7 @@ from glob import glob
 from .util import prepare_command, get_build_verbosity_extra_flags
 
 
-def build(project_dir, package_name, output_dir, test_command, test_requires, before_build, build_verbosity, skip, environment):
+def build(project_dir, package_name, output_dir, test_command, test_requires, before_build, build_verbosity, skip, environment, from_pypi):
     # run_with_env is a cmd file that sets the right environment variables to
     run_with_env = os.path.join(tempfile.gettempdir(), 'appveyor_run_with_env.cmd')
     if not os.path.exists(run_with_env):
@@ -85,7 +85,7 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             shell([before_build_prepared], env=env)
 
         # build the wheel
-        shell(['pip', 'wheel', abs_project_dir, '-w', built_wheel_dir, '--no-deps'] + get_build_verbosity_extra_flags(build_verbosity), env=env)
+        shell(['pip', 'wheel', from_pypi or abs_project_dir, '-w', built_wheel_dir, '--no-deps'] + get_build_verbosity_extra_flags(build_verbosity), env=env)
         built_wheel = glob(built_wheel_dir+'/*.whl')[0]
 
         # install the wheel


### PR DESCRIPTION
First step towards addressing #93.

A nice extra is that I expect this will also work for a value `my-pypi-package==0.42.1`, building (or downloading, if the wheel already exists) that specific release.

Things to do, if this approach works:
- [ ] Does this need to be an environment variable option (as I've made it, for the moment), or the suggested `--from-pypi=...` argument?
- [ ] Document this feature in `README.md` (depending on the actual form the option will take).
- [ ] Not sure what's the best way to test this without actually using a project that's already been uploaded to PyPI. @astrofrog, maybe you could give it a shot, using this branch to build your project?
- [ ] The list of arguments to the different platform functions is getting quite long. What about introducing a `collections.namedtuple` (e.g., `BuildOptions`) to nicely wrap all the options and only pass one argument to `linux.build`/`macos.build`/`windows.build`?


EDIT: Sorry about initially pushing the commit to the master. Something went wrong, there.