### PR TITLE
Pinning version of wheel to install to 0.31.1 on macOS

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -54,6 +54,12 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             mkdir /output
             cd /project
 
+            # Fix for changes in Wheel API, until auditwheel updates (see #106)
+            # Note: The global auditwheel is used (rather thatn the one in $PYBIN, during the loop),
+            # so we need to pin this version just once, in the version of Python where auditwheel is installed
+            # See https://github.com/pypa/manylinux/blob/master/docker/build_scripts/build.sh#L123-L126
+            /opt/python/cp36-cp36m/bin/pip install wheel==0.31.1
+
             {environment_exports}
 
             for PYBIN in {pybin_paths}; do

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -87,7 +87,8 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
         call(['python', get_pip_script, '--no-setuptools', '--no-wheel'], env=env)
         call(['pip', '--version'], env=env)
         call(['pip', 'install', '--upgrade', 'setuptools'], env=env)
-        call(['pip', 'install', 'wheel'], env=env)
+        # Fix for changes in Wheel API, until delocate updates (see #106)
+        call(['pip', 'install', 'wheel==0.31.1'], env=env)
         call(['pip', 'install', 'delocate'], env=env)
 
         # setup dirs


### PR DESCRIPTION
See discussion in issue #106

It will depend on when the delocate dependency releases a new version whether we want this merged or not. But for now, this fix can be used by `pip` installing `git+https://github.com/joerick/cibuildwheel.git@wheel-0.31.1` or `https://github.com/joerick/cibuildwheel/archive/wheel-0.31.1.zip`.