### PR TITLE
Fixing "AttributeError: 'Popen' object has no attribute 'args'" on Python 2.7 for Linux builds

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -122,15 +122,15 @@ def build(project_dir, package_name, output_dir, test_command, test_requires, be
             if stdin_str is None:
                 subprocess.check_call(['docker'] + command)
             else:
-                process = subprocess.Popen(['docker'] + command,
-                                           stdin=subprocess.PIPE, universal_newlines=True)
+                args = ['docker'] + command
+                process = subprocess.Popen(args, stdin=subprocess.PIPE, universal_newlines=True)
                 try:
                     process.communicate(stdin_str)
                 except KeyboardInterrupt:
                     process.kill()
                     process.wait()
                 if process.returncode != 0:
-                    raise subprocess.CalledProcessError(process.returncode, process.args)
+                    raise subprocess.CalledProcessError(process.returncode, args)
 
         container_name = 'cibuildwheel-{}'.format(uuid.uuid4())
         try:


### PR DESCRIPTION
Silly thing, but Python 2.7's `subprocess.Popen` object does not have an `args` attribute, and so you now get an extra exception instead of a nice overview of the executed command, when the subprocess fails.