### PR TITLE
Add apriltags2-ethz library to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Here are some repos that use cibuildwheel.
 - [pybase64](https://github.com/mayeut/pybase64)
 - [KDEpy](https://github.com/tommyod/KDEpy)
 - [AutoPy](https://github.com/autopilot-rs/autopy)
+- [apriltags2-ethz](https://github.com/safijari/apriltags2_ethz)
 
 > Add repo here! Send a PR.
 


### PR DESCRIPTION
Adding a link to my library that is using cibuildwheel to build linux wheels. Not currently deploying to PyPI but will soon :).

Thank you for this awesome tool.