### PR TITLE
Sorting build options dict items when printing preamble

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -180,7 +180,7 @@ def print_preamble(platform, build_options):
 
     print('Build options:')
     print('  platform: %r' % platform)
-    for option, value in build_options.items():
+    for option, value in sorted(build_options.items()):
         print('  %s: %r' % (option, value))
 
     warnings = detect_warnings(platform, build_options)


### PR DESCRIPTION
Silly thing, but I was very confused while looking at the tests, seeing that the build options are were always in a different order (for example [here](https://ci.appveyor.com/project/joerick/cibuildwheel/builds/20661534/job/3iec2iin8gcwfr87#L1176) vs. [here](https://ci.appveyor.com/project/joerick/cibuildwheel/builds/20661534/job/3iec2iin8gcwfr87#L1609)) and this really annoys me, somehow.

The quickest solution I could think of was sorting the `build_options.items()` when printing. If this is not worth it or if there's a better order, do please tell me.