### PR TITLE
Running 'pip install --upgrade setuptools' with 'sudo' on macOS, fixing #122

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -86,7 +86,8 @@ def build(project_dir, output_dir, test_command, test_requires, before_build, bu
         # install pip & wheel
         call(['python', get_pip_script, '--no-setuptools', '--no-wheel'], env=env)
         call(['pip', '--version'], env=env)
-        call(['pip', 'install', '--upgrade', 'setuptools'], env=env)
+        # sudo required, because the removal of the old version of setuptools might cause problems with newer pip versions (see issue #122)
+        call(['sudo', 'pip', 'install', '--upgrade', 'setuptools'], env=env)
         call(['pip', 'install', 'wheel'], env=env)
         call(['pip', 'install', 'delocate'], env=env)
 


### PR DESCRIPTION
Seems the fix to `pip` to #122 might still take some time to get released, and is not guaranteed to completely fix our problem. Adding `--user` to all `pip install` commands on macOS should be a harmless (?) fix to get `cibuildwheel` working again, though.

The other option would be to add `sudo` to the `pip install --upgrade setuptools` call. If you prefer that, I can change this PR.