### PR TITLE
Fixing issue #127 by avoiding bashlex 0.13 in 'install_requires'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 setup(
     name='cibuildwheel',
     version='0.10.1',
-    install_requires=['bashlex'],
+    install_requires=['bashlex!=0.13'],
     description="Build Python wheels on CI with minimal configuration.",
     long_description='For readme please see http://github.com/joerick/cibuildwheel',
     author="Joe Rickerby",


### PR DESCRIPTION
One possible fix on our end for #127; see https://github.com/joerick/cibuildwheel/issues/127#issuecomment-471284771

Even if we choose to not go for this particular solution, this helps #127 and demonstrates that it's not `pip`, Travis CI, or `cibuildwheel`, but the update of `bashlex` (see https://travis-ci.org/YannickJadoul/cibuildwheel/builds/504299250 vs. https://travis-ci.org/YannickJadoul/cibuildwheel/builds/504301454).