### PR TITLE
Revert temporary fix of #122

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -86,8 +86,7 @@ def build(project_dir, output_dir, test_command, test_requires, before_build, bu
         # install pip & wheel
         call(['python', get_pip_script, '--no-setuptools', '--no-wheel'], env=env)
         call(['pip', '--version'], env=env)
-        # sudo required, because the removal of the old version of setuptools might cause problems with newer pip versions (see issue #122)
-        call(['sudo', 'pip', 'install', '--upgrade', 'setuptools'], env=env)
+        call(['pip', 'install', '--upgrade', 'setuptools'], env=env)
         call(['pip', 'install', 'wheel'], env=env)
         call(['pip', 'install', 'delocate'], env=env)
 


### PR DESCRIPTION
While I was looking at #127, I realized the temporary fix to #122 (which turned out to be a similar but unrelated issue) is not necessary anymore now that `pip` has been patched, fixing the issue.

If @joerick would decide to release a new version soon to include #128, then this might as well be part of it, too?

This PR would (finally!) close #122.

And, oh, yes: I've based it on #128, to get the tests green, so I'd suggest to first merge #128, and then I could rebase this PR?