### PR TITLE
Updating version of Python 2.7 to 2.7.16 on macOS

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -13,7 +13,7 @@ from .util import prepare_command, get_build_verbosity_extra_flags
 def build(project_dir, output_dir, test_command, test_requires, before_build, build_verbosity, build_selector, environment):
     PythonConfiguration = namedtuple('PythonConfiguration', ['version', 'identifier', 'url'])
     python_configurations = [
-        PythonConfiguration(version='2.7', identifier='cp27-macosx_10_6_intel', url='https://www.python.org/ftp/python/2.7.15/python-2.7.15-macosx10.6.pkg'),
+        PythonConfiguration(version='2.7', identifier='cp27-macosx_10_6_intel', url='https://www.python.org/ftp/python/2.7.16/python-2.7.16-macosx10.6.pkg'),
         PythonConfiguration(version='3.4', identifier='cp34-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.4.4/python-3.4.4-macosx10.6.pkg'),
         PythonConfiguration(version='3.5', identifier='cp35-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg'),
         PythonConfiguration(version='3.6', identifier='cp36-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.6.pkg'),


### PR DESCRIPTION
@joerick, if you are creating a new release anyway, then there's a new Python 2.7 version, as well.