### PR TITLE
Update openssl patch from 1.0.2q to 1.0.2r on macOS

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -55,7 +55,7 @@ def build(project_dir, output_dir, test_command, test_requires, before_build, bu
             call(['sudo', 'installer', '-pkg', '/tmp/Python.pkg', '-target', '/'])
             # patch open ssl
             if config.version in ('3.4', '3.5'):
-                call(['curl', '-fsSLo', '/tmp/python-patch.tar.gz', 'https://github.com/mayeut/patch-macos-python-openssl/releases/download/v1.0.2q/patch-macos-python-%s-openssl-v1.0.2q.tar.gz' % config.version])
+                call(['curl', '-fsSLo', '/tmp/python-patch.tar.gz', 'https://github.com/mayeut/patch-macos-python-openssl/releases/download/v1.0.2r/patch-macos-python-%s-openssl-v1.0.2r.tar.gz' % config.version])
                 call(['sudo', 'tar', '-C', '/Library/Frameworks/Python.framework/Versions/%s/' % config.version, '-xmf', '/tmp/python-patch.tar.gz'])
 
         installation_bin_path = '/Library/Frameworks/Python.framework/Versions/{}/bin'.format(config.version)


### PR DESCRIPTION
Fixes CVE, c.f. https://www.openssl.org/news/cl102.txt