### PR TITLE
Adding support for building manylinux2010 wheels

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -129,11 +129,10 @@ def main():
     )
 
     if platform == 'linux':
-        manylinux1_x86_64_image = os.environ.get('CIBW_MANYLINUX1_X86_64_IMAGE', None)
-        manylinux1_i686_image = os.environ.get('CIBW_MANYLINUX1_I686_IMAGE', None)
-
         build_options.update(
-            manylinux1_images={'x86_64': manylinux1_x86_64_image, 'i686': manylinux1_i686_image},
+            manylinux_images={'manylinux1_x86_64': os.environ.get('CIBW_MANYLINUX1_X86_64_IMAGE', None),
+                              'manylinux1_i686': os.environ.get('CIBW_MANYLINUX1_I686_IMAGE', None),
+                              'manylinux2010_x86_64': os.environ.get('CIBW_MANYLINUX2010_X86_64_IMAGE', None)},
         )
     elif platform == 'macos':
         pass

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -87,10 +87,11 @@ def build(project_dir, output_dir, test_command, test_requires, before_build, bu
                 if [[ "$built_wheel" == *none-any.whl ]]; then
                     # pure python wheel - just copy
                     mv "$built_wheel" /tmp/delocated_wheel
+                    delocated_wheel=(/tmp/delocated_wheel/*.whl)
                 else
                     auditwheel repair --plat {platform_tag} "$built_wheel" -w /tmp/delocated_wheel
+                    delocated_wheel=(/tmp/delocated_wheel/*-{platform_tag}.whl)
                 fi
-                delocated_wheel=(/tmp/delocated_wheel/*.whl)
 
                 # Install the wheel we just built
                 "$PYBIN/pip" install "$delocated_wheel"

--- a/test/06_docker_images/cibuildwheel_test.py
+++ b/test/06_docker_images/cibuildwheel_test.py
@@ -8,13 +8,12 @@ def test():
         pytest.skip('the docker test is only relevant to the linux build')
 
     utils.cibuildwheel_run(project_dir, add_env={
-        'CIBW_MANYLINUX1_X86_64_IMAGE': 'dockcross/manylinux-x64',
-        'CIBW_MANYLINUX1_I686_IMAGE': 'dockcross/manylinux-x86',
-        'CIBW_SKIP': '*-manylinux2010_*',  # No dockcross image for manylinux2010 (yet)
+        'CIBW_MANYLINUX1_X86_64_IMAGE': 'dockcross/manylinux1-x64',
+        'CIBW_MANYLINUX1_I686_IMAGE': 'dockcross/manylinux1-x86',
+        'CIBW_MANYLINUX2010_X86_64_IMAGE': 'dockcross/manylinux2010-x64',
     })
 
     # also check that we got the right wheels built
-    expected_wheels = [w for w in utils.expected_wheels('spam', '0.1.0')
-                       if '-manylinux2010' not in w]
+    expected_wheels = [w for w in utils.expected_wheels('spam', '0.1.0')]
     actual_wheels = os.listdir('wheelhouse')
     assert set(actual_wheels) == set(expected_wheels)

--- a/test/08_manylinux2010_only/cibuildwheel_test.py
+++ b/test/08_manylinux2010_only/cibuildwheel_test.py
@@ -7,14 +7,16 @@ def test():
     if utils.platform != 'linux':
         pytest.skip('the docker test is only relevant to the linux build')
 
+    # build the wheels
+    # CFLAGS environment veriable is ecessary to fail on 'malloc_info' (on manylinux1) during compilation/linking,
+    # rather than when dynamically loading the Python 
     utils.cibuildwheel_run(project_dir, add_env={
-        'CIBW_MANYLINUX1_X86_64_IMAGE': 'dockcross/manylinux-x64',
-        'CIBW_MANYLINUX1_I686_IMAGE': 'dockcross/manylinux-x86',
-        'CIBW_SKIP': '*-manylinux2010_*',  # No dockcross image for manylinux2010 (yet)
+        'CIBW_ENVIRONMENT': 'CFLAGS="$CFLAGS -Werror=implicit-function-declaration"',
+        'CIBW_SKIP': '*-manylinux1_*',
     })
-
-    # also check that we got the right wheels built
+    
+    # also check that we got the right wheels
     expected_wheels = [w for w in utils.expected_wheels('spam', '0.1.0')
-                       if '-manylinux2010' not in w]
+                       if '-manylinux1_' not in w]
     actual_wheels = os.listdir('wheelhouse')
     assert set(actual_wheels) == set(expected_wheels)

--- a/test/08_manylinux2010_only/environment.json
+++ b/test/08_manylinux2010_only/environment.json
@@ -1,4 +1,4 @@
 {
     "CIBW_ENVIRONMENT": "CFLAGS=\"$CFLAGS -Werror=implicit-function-declaration\"",
-    "CIBW_TEST_COMMAND": "python -c \"import spam\""
+    "CIBW_SKIP": "*-manylinux1_*"
 }

--- a/test/08_manylinux2010_only/environment.json
+++ b/test/08_manylinux2010_only/environment.json
@@ -1,4 +1,0 @@
-{
-    "CIBW_ENVIRONMENT": "CFLAGS=\"$CFLAGS -Werror=implicit-function-declaration\"",
-    "CIBW_SKIP": "*-manylinux1_*"
-}

--- a/test/08_manylinux2010_only/environment.json
+++ b/test/08_manylinux2010_only/environment.json
@@ -1,0 +1,3 @@
+{
+    "CIBW_SKIP": "*-manylinux1"
+}

--- a/test/08_manylinux2010_only/environment.json
+++ b/test/08_manylinux2010_only/environment.json
@@ -1,3 +1,4 @@
 {
-    "CIBW_SKIP": "*-manylinux1"
+    "CIBW_ENVIRONMENT": "CFLAGS=\"$CFLAGS -Werror=implicit-function-declaration\"",
+    "CIBW_TEST_COMMAND": "python -c \"import spam\""
 }

--- a/test/08_manylinux2010_only/setup.py
+++ b/test/08_manylinux2010_only/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, Extension
+
+setup(
+    name="spam",
+    ext_modules=[Extension('spam', sources=['spam.c'])],
+    version="0.1.0",
+)

--- a/test/08_manylinux2010_only/spam.c
+++ b/test/08_manylinux2010_only/spam.c
@@ -1,0 +1,55 @@
+#include <Python.h>
+#if defined(__linux__)
+#include <malloc.h>
+#endif
+
+static PyObject *
+spam_system(PyObject *self, PyObject *args)
+{
+    const char *command;
+    int sts;
+
+    if (!PyArg_ParseTuple(args, "s", &command))
+        return NULL;
+
+    sts = malloc_info(0, stdout);
+    if (sts == 0) {
+        sts = system(command);
+    }
+    return PyLong_FromLong(sts);
+}
+
+/* Module initialization */
+
+#if PY_MAJOR_VERSION >= 3
+    #define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
+    #define MOD_DEF(m, name, doc, methods, module_state_size) \
+        static struct PyModuleDef moduledef = { \
+            PyModuleDef_HEAD_INIT, name, doc, module_state_size, methods, }; \
+        m = PyModule_Create(&moduledef);
+    #define MOD_RETURN(m) return m;
+#else
+    #define MOD_INIT(name) PyMODINIT_FUNC init##name(void)
+    #define MOD_DEF(m, name, doc, methods, module_state_size) \
+        m = Py_InitModule3(name, methods, doc);
+    #define MOD_RETURN(m) return;
+#endif
+
+static PyMethodDef module_methods[] = {
+    {"system", (PyCFunction)spam_system, METH_VARARGS, 
+     "Execute a shell command."},
+    {NULL}  /* Sentinel */
+};
+
+MOD_INIT(spam)
+{
+    PyObject* m;
+
+    MOD_DEF(m, 
+            "spam", 
+            "Example module", 
+            module_methods,
+            -1)
+
+    MOD_RETURN(m)
+}

--- a/test/08_manylinux2010_only/spam.c
+++ b/test/08_manylinux2010_only/spam.c
@@ -7,12 +7,14 @@ static PyObject *
 spam_system(PyObject *self, PyObject *args)
 {
     const char *command;
-    int sts;
+    int sts = 0;
 
     if (!PyArg_ParseTuple(args, "s", &command))
         return NULL;
 
+#if defined(__linux__)
     sts = malloc_info(0, stdout);
+#endif
     if (sts == 0) {
         sts = system(command);
     }

--- a/test/shared/utils.py
+++ b/test/shared/utils.py
@@ -58,6 +58,12 @@ def expected_wheels(package_name, package_version):
             '{package_name}-{package_version}-cp35-cp35m-manylinux1_i686.whl',
             '{package_name}-{package_version}-cp36-cp36m-manylinux1_i686.whl',
             '{package_name}-{package_version}-cp37-cp37m-manylinux1_i686.whl',
+            '{package_name}-{package_version}-cp27-cp27m-manylinux2010_x86_64.whl',
+            '{package_name}-{package_version}-cp27-cp27mu-manylinux2010_x86_64.whl',
+            '{package_name}-{package_version}-cp34-cp34m-manylinux2010_x86_64.whl',
+            '{package_name}-{package_version}-cp35-cp35m-manylinux2010_x86_64.whl',
+            '{package_name}-{package_version}-cp36-cp36m-manylinux2010_x86_64.whl',
+            '{package_name}-{package_version}-cp37-cp37m-manylinux2010_x86_64.whl',
         ]
     elif platform == 'windows':
         templates = [


### PR DESCRIPTION
That was actually easier than expected (if it now also works, of course). See also #65.

A few comments/remarks/things to consider:
- I like the tag approach, but do we build everything, by default? Do we let `cibuildwheel` generate both `manylinux1` and `manylinux2010` wheels, by default?
- `manylinux2010` is almost there, but still considered experimental. If this works, do we release a new version that builds `manylinux2010` by default, or do we turn it of by default?
- `manylinux2010_i686` is not available yet. [This page](https://packaging.python.org/specifications/platform-compatibility-tags/#manylinux-tags) seems to indicate it will still be created at some point.
- Soon, we might not need to set the `--plat` argument to `auditwheel repair` anymore: https://github.com/matthew-brett/multibuild/issues/238#issuecomment-484684645
- When wheels are both `manylinux1` and `manylinux2010` compatible, `auditwheel repair` will produce both (see https://github.com/pypa/manylinux/issues/179#issuecomment-482217731 and https://github.com/pypa/python-manylinux-demo/pull/19). So `delocated_wheel=(/tmp/delocated_wheel/*.whl)` and `"$delocated_wheel"` to select the first won't work anymore? (I'm testing this in a minute to confirm this.)
- A few minor things in the code, but I'll review myself and comment on it.