### PR TITLE
Custom test checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,8 @@ Options
 -------
 
 ```
-usage: cibuildwheel [-h]
-                    [--output-dir OUTPUT_DIR]
-                    [--platform PLATFORM]
+usage: cibuildwheel [-h] [--platform {auto,linux,macos,windows}]
+                    [--output-dir OUTPUT_DIR] [--print-build-identifiers]
                     [project_dir]
     
 Build wheels for all the platforms.
@@ -174,7 +173,10 @@ optional arguments:
                         you need to run in Windows, and it will build and test
                         for all versions of Python at C:\PythonXX[-x64].
   --output-dir OUTPUT_DIR
-                        Destination folder for the wheels. 
+                        Destination folder for the wheels.
+  --print-build-identifiers
+                        Print the build identifiers matched by the current
+                        invocation and exit.
 
 ```
 

--- a/bin/run_test.py
+++ b/bin/run_test.py
@@ -22,7 +22,7 @@ def single_run(test_project):
     print('%s built successfully. %i wheels built.' % (test_project, len(wheels)))
 
     # check some wheels were actually built
-    assert len(wheels) >= 3
+    subprocess.check_call([sys.executable, os.path.join(test_project, 'check.py')])
 
     # clean up
     shutil.rmtree('wheelhouse')

--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
 
     ### run the integration tests
 
-    test_projects = glob('test/??_*')
+    test_projects = sorted(glob('test/??_*'))
 
     if len(test_projects) == 0:
         print('No test projects found. Aborting.', file=sys.stderr)

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -48,6 +48,10 @@ def main():
                         help=('Path to the project that you want wheels for. Default: the current '
                               'directory.'))
 
+    parser.add_argument('--print-build-identifiers',
+                        action='store_true',
+                        help='Print the build identifiers matched by the current invocation and exit.')
+
     args = parser.parse_args()
 
     if args.platform != 'auto':
@@ -109,6 +113,10 @@ def main():
         print('cibuildwheel: Could not find setup.py at root of project', file=sys.stderr)
         exit(2)
 
+    if args.print_build_identifiers:
+        print_build_identifiers(platform, build_selector)
+        exit(0)
+
     build_options = dict(
         project_dir=project_dir,
         output_dir=output_dir,
@@ -149,6 +157,7 @@ def main():
     else:
         raise Exception('Unsupported platform')
 
+
 def print_preamble(platform, build_options):
     print(textwrap.dedent('''
              _ _       _ _   _       _           _
@@ -172,6 +181,21 @@ def print_preamble(platform, build_options):
             print('  ' + warning)
 
     print('\nHere we go!\n')
+
+
+def print_build_identifiers(platform, build_selector):
+    if platform == 'linux':
+        python_configurations = cibuildwheel.linux.get_python_configurations(build_selector)
+    elif platform == 'windows':
+        python_configurations = cibuildwheel.windows.get_python_configurations(build_selector)
+    elif platform == 'macos':
+        python_configurations = cibuildwheel.macos.get_python_configurations(build_selector)
+    else:
+        python_configurations = []
+
+    for config in python_configurations:
+        print(config.identifier)
+
 
 def detect_warnings(platform, build_options):
     warnings = []

--- a/test/01_basic/check.py
+++ b/test/01_basic/check.py
@@ -1,0 +1,9 @@
+import glob
+import subprocess
+import sys
+
+build_identifiers = subprocess.check_output([sys.executable, '-m', 'cibuildwheel', '--print-build-identifiers'], universal_newlines=True).strip().split('\n')
+expected_identifiers = build_identifiers
+built_wheels = glob.glob('wheelhouse/*.whl')
+
+assert len(built_wheels) == len(expected_identifiers)

--- a/test/02_test/check.py
+++ b/test/02_test/check.py
@@ -1,0 +1,9 @@
+import glob
+import subprocess
+import sys
+
+build_identifiers = subprocess.check_output([sys.executable, '-m', 'cibuildwheel', '--print-build-identifiers'], universal_newlines=True).strip().split('\n')
+expected_identifiers = build_identifiers
+built_wheels = glob.glob('wheelhouse/*.whl')
+
+assert len(built_wheels) == len(expected_identifiers)

--- a/test/03_before_build/check.py
+++ b/test/03_before_build/check.py
@@ -1,0 +1,9 @@
+import glob
+import subprocess
+import sys
+
+build_identifiers = subprocess.check_output([sys.executable, '-m', 'cibuildwheel', '--print-build-identifiers'], universal_newlines=True).strip().split('\n')
+expected_identifiers = build_identifiers
+built_wheels = glob.glob('wheelhouse/*.whl')
+
+assert len(built_wheels) == len(expected_identifiers)

--- a/test/04_build_skip/check.py
+++ b/test/04_build_skip/check.py
@@ -1,0 +1,9 @@
+import glob
+import subprocess
+import sys
+
+build_identifiers = subprocess.check_output([sys.executable, '-m', 'cibuildwheel', '--print-build-identifiers'], universal_newlines=True).strip().split('\n')
+expected_identifiers = [identifier for identifier in build_identifiers if "cp3" in identifier and "cp34" not in identifier]
+built_wheels = glob.glob('wheelhouse/*.whl')
+
+assert len(built_wheels) == len(expected_identifiers)

--- a/test/05_environment/check.py
+++ b/test/05_environment/check.py
@@ -1,0 +1,9 @@
+import glob
+import subprocess
+import sys
+
+build_identifiers = subprocess.check_output([sys.executable, '-m', 'cibuildwheel', '--print-build-identifiers'], universal_newlines=True).strip().split('\n')
+expected_identifiers = build_identifiers
+built_wheels = glob.glob('wheelhouse/*.whl')
+
+assert len(built_wheels) == len(expected_identifiers)

--- a/test/06_docker_images/check.py
+++ b/test/06_docker_images/check.py
@@ -1,0 +1,9 @@
+import glob
+import subprocess
+import sys
+
+build_identifiers = subprocess.check_output([sys.executable, '-m', 'cibuildwheel', '--print-build-identifiers'], universal_newlines=True).strip().split('\n')
+expected_identifiers = build_identifiers
+built_wheels = glob.glob('wheelhouse/*.whl')
+
+assert len(built_wheels) == len(expected_identifiers)

--- a/test/06_docker_images/check.py
+++ b/test/06_docker_images/check.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 
 build_identifiers = subprocess.check_output([sys.executable, '-m', 'cibuildwheel', '--print-build-identifiers'], universal_newlines=True).strip().split('\n')
-expected_identifiers = build_identifiers
+expected_identifiers = [identifier for identifier in build_identifiers if 'macos' not in identifier and 'win' not in identifier]
 built_wheels = glob.glob('wheelhouse/*.whl')
 
 assert len(built_wheels) == len(expected_identifiers)

--- a/test/06_docker_images/environment.json
+++ b/test/06_docker_images/environment.json
@@ -1,5 +1,5 @@
 {
     "CIBW_MANYLINUX1_X86_64_IMAGE": "dockcross/manylinux-x64",
     "CIBW_MANYLINUX1_I686_IMAGE": "dockcross/manylinux-x86",
-    "CIBW_SKIP": "cp37-manylinux*"
+    "CIBW_SKIP": "*macos* *win*"
 }

--- a/test/07_ssl/check.py
+++ b/test/07_ssl/check.py
@@ -1,0 +1,9 @@
+import glob
+import subprocess
+import sys
+
+build_identifiers = subprocess.check_output([sys.executable, '-m', 'cibuildwheel', '--print-build-identifiers'], universal_newlines=True).strip().split('\n')
+expected_identifiers = build_identifiers
+built_wheels = glob.glob('wheelhouse/*.whl')
+
+assert len(built_wheels) == len(expected_identifiers)


### PR DESCRIPTION
Cfr. #103 (after having come up in #135 again)

For each integration test, `check.py` is now called instead of asserting the number of wheels present. To reduce code duplication, I've also implemented a solution to #105.