### PR TITLE
Correct spelling: capitalized 'V' in 'AppVeyor'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ cibuildwheel
 
 Python wheels are great. Building them across **Mac, Linux, Windows**, on **multiple versions of Python**, is not.
 
-`cibuildwheel` is here to help. `cibuildwheel` runs on your CI server - currently it supports Azure Pipelines, Travis CI, Appveyor, and CircleCI - and it builds and tests your wheels across all of your platforms.
+`cibuildwheel` is here to help. `cibuildwheel` runs on your CI server - currently it supports Azure Pipelines, Travis CI, AppVeyor, and CircleCI - and it builds and tests your wheels across all of your platforms.
 
 **`cibuildwheel` is in beta**. It's brand new - I'd love for you to try it and help make it better!
 
@@ -22,23 +22,23 @@ What does it do?
 
 > \* Not supported on Azure Pipelines
 
-- Builds manylinux, macOS and Windows (32 and 64bit) wheels using Azure Pipelines, Travis CI, Appveyor, and CircleCI
+- Builds manylinux, macOS and Windows (32 and 64bit) wheels using Azure Pipelines, Travis CI, AppVeyor, and CircleCI
 - Bundles shared library dependencies on Linux and macOS through [auditwheel](https://github.com/pypa/auditwheel) and [delocate](https://github.com/matthew-brett/delocate)
 - Runs the library test suite against the wheel-installed version of your library
 
 Usage
 -----
 
-`cibuildwheel` currently works  **Travis CI** and **CircleCI** to build Linux and Mac wheels, and **Appveyor** to build Windows wheels. **Azure Pipelines** supports all three.
+`cibuildwheel` currently works  **Travis CI** and **CircleCI** to build Linux and Mac wheels, and **AppVeyor** to build Windows wheels. **Azure Pipelines** supports all three.
 
 |                 | Linux | macOS | Windows |
 |-----------------|-------|-------|---------|
 | Azure Pipelines | ✅    | ✅    | ✅      |
 | Travis CI       | ✅    | ✅    |         |
-| Appveyor        |       |       | ✅      |
+| AppVeyor        |       |       | ✅      |
 | CircleCI        | ✅    | ✅    |         |
 
-`cibuildwheel` is not intended to run on your development machine. It will try to install packages globally; this is no good. Travis CI, CircleCI, and Appveyor run their builds in isolated environments, so are ideal for this kind of script.
+`cibuildwheel` is not intended to run on your development machine. It will try to install packages globally; this is no good. Travis CI, CircleCI, and AppVeyor run their builds in isolated environments, so are ideal for this kind of script.
 
 ### Minimal setup
 
@@ -184,11 +184,11 @@ jobs:
 
 
 <details>
-    <summary><b>Appveyor</b>
+    <summary><b>AppVeyor</b>
         <img width="16" src="https://unpkg.com/simple-icons@latest/icons/windows.svg" />
     </summary>
 
-- To build Windows wheels on Appveyor, create an `appveyor.yml` file in your repo.
+- To build Windows wheels on AppVeyor, create an `appveyor.yml` file in your repo.
 
     ```
     build_script:
@@ -199,11 +199,11 @@ jobs:
         name: Wheels
     ```
     
-  Appveyor will store the built wheels for you - you can access them from the project console. Alternatively, you may want to store them in the same place as the Travis CI build. See [Appveyor deployment docs](https://www.appveyor.com/docs/deployment/) for more info, or see [Delivering to PyPI](#delivering-to-pypi) below.
+  AppVeyor will store the built wheels for you - you can access them from the project console. Alternatively, you may want to store them in the same place as the Travis CI build. See [AppVeyor deployment docs](https://www.appveyor.com/docs/deployment/) for more info, or see [Delivering to PyPI](#delivering-to-pypi) below.
     
 </details>
 
-- Commit those files, enable building of your repo on Travis CI and Appveyor, and push.
+- Commit those files, enable building of your repo on Travis CI and AppVeyor, and push.
 
 All being well, you should get wheels delivered to you in a few minutes. 
 
@@ -629,7 +629,7 @@ _7 September 2017_
 _14 August 2017_
 
 - 🐛 Fixed a bug on Windows where subprocess' output was hidden (#23)
-- 🐛 Fixed a bug on Appveyor where logs would appear in the wrong order due to output buffering (#24, thanks @YannickJadoul!)
+- 🐛 Fixed a bug on AppVeyor where logs would appear in the wrong order due to output buffering (#24, thanks @YannickJadoul!)
 
 ### 0.4.0
 

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -82,7 +82,7 @@ def main():
 
         if platform is None:
             print('cibuildwheel: Unable to detect platform. cibuildwheel should run on your CI server, '
-                  'Travis CI, Appveyor, and CircleCI are supported. You can run on your development '
+                  'Travis CI, AppVeyor, and CircleCI are supported. You can run on your development '
                   'machine using the --platform argument. Check --help output for more '
                   'information.',
                   file=sys.stderr)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -23,7 +23,7 @@ def get_python_path(config):
         except IndexError:
             raise Exception('Could not find a Python install at ' + path_pattern)
     else:
-        # Assume we're running on Appveyor
+        # Assume we're running on AppVeyor
         major, minor = config.version.split('.')[:2]
         return 'C:\\Python{major}{minor}{arch}'.format(
             major=major,
@@ -66,7 +66,7 @@ def build(project_dir, output_dir, test_command, test_requires, before_build, bu
         run_with_env = os.path.abspath(os.path.join(os.path.dirname(__file__), 'resources', 'appveyor_run_with_env.cmd'))
 
         # run_with_env is a cmd file that sets the right environment variables
-        # to build on Appveyor.
+        # to build on AppVeyor.
         def shell(args, env=None, cwd=None):
             # print the command executing for the logs
             print('+ ' + ' '.join(args))


### PR DESCRIPTION
This is not an improvement and even less than a minor change, but incorrect spelling may be confusing. ;)

![AppVeyor Logo](https://dka575ofm4ao0.cloudfront.net/pages-transactional_logos/retina/16896/ApwXsQaJT16xVdsGs7aY)