### PR TITLE
Remove example of using yum install

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ The active Python binary can be accessed using `python`, and pip with `pip`; `ci
 
 Example: `pip install .`  
 Example: `pip install pybind11`  
-Example: `yum install -y libffi-dev && pip install .`
+Example: `cd depedency && ./configure && make install && cd .. && pip install .`
 
 Platform-specific variants also available:  
  `CIBW_BEFORE_BUILD_MACOS` | `CIBW_BEFORE_BUILD_WINDOWS` | `CIBW_BEFORE_BUILD_LINUX`


### PR DESCRIPTION
Since CentOS 5 is 2.5 years old past of end of life, it's not recommend to use its binaries as they may have unpatched vulnerabilities. It's better to build any dependencies not on the whitelist from source.

The manylinux2010 image should be fine in this respect.