### PR TITLE
Run tests in clean virtual environment

### DIFF
--- a/test/02_test/cibuildwheel_test.py
+++ b/test/02_test/cibuildwheel_test.py
@@ -10,7 +10,7 @@ def test():
         # the 'false ||' bit is to ensure this command runs in a shell on
         # mac/linux.
         'CIBW_TEST_COMMAND': 'false || nosetests {project}/test',
-        'CIBW_TEST_COMMAND_WINDOWS': 'nosetests {project}/test',
+        'CIBW_TEST_COMMAND_WINDOWS': 'nosetests {project}/test'
     })
 
     # also check that we got the right wheels
@@ -28,7 +28,7 @@ def test_extras_require():
         # the 'false ||' bit is to ensure this command runs in a shell on
         # mac/linux.
         'CIBW_TEST_COMMAND': 'false || nosetests {project}/test',
-        'CIBW_TEST_COMMAND_WINDOWS': 'nosetests {project}/test',
+        'CIBW_TEST_COMMAND_WINDOWS': 'nosetests {project}/test'
     })
 
     # also check that we got the right wheels


### PR DESCRIPTION
This fixes https://github.com/joerick/cibuildwheel/issues/121 by making it so that once the wheels are built, the tests are run in an isolated environment. This ensures isolation from the build environment and guarantees that the package is correctly defining its build and test-time dependencies.

I originally attempted to solve this with direct calls to virtualenv, but ran into issues with some of the CI tests here, which suggested to me that this was not a robust solution. I therefore have now taken the approach of using tox. The process is as follows:

* Create an empty temporary directory
* Write a simple tox configuration to that directory that installs the wheels, the test dependencies, and runs the test command
* Run tox in that directory

The tox configuration whitelists all external commands since it's hard to know what non-Python commands people might be relying on. For now we also do not pass any environment variables into the test environment.

If there are concerns that this could break existing projects (it's always hard to account for all corner cases) this behavior could be made opt-in, with the previous behavior being the default. Another idea would be to make it opt-in initially, and then choose to make it the default later once it's been stress tested by some projects.