### PR TITLE
Clean up CircleCI YAML syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,10 @@ jobs:
 
       - run:
           name: Prepare the environment.
-          command: |
-            bash .circleci/prepare.sh
+          command: bash .circleci/prepare.sh
       - run:
           name: Test.
-          command: |
-            venv/bin/python ./bin/run_tests.py
+          command: venv/bin/python ./bin/run_tests.py
 
   osx-python3:
     macos:
@@ -28,12 +26,10 @@ jobs:
 
       - run:
           name: Prepare the environment.
-          command: |
-            bash .circleci/prepare.sh
+          command: bash .circleci/prepare.sh
       - run:
           name: Test.
-          command: |
-            venv/bin/python ./bin/run_tests.py
+          command: venv/bin/python ./bin/run_tests.py
 
   linux-python2:
     docker:
@@ -46,12 +42,10 @@ jobs:
 
       - run:
           name: Prepare the environment.
-          command: |
-            bash .circleci/prepare.sh
+          command: bash .circleci/prepare.sh
       - run:
           name: Test.
-          command: |
-            venv/bin/python ./bin/run_tests.py
+          command: venv/bin/python ./bin/run_tests.py
 
   linux-python3:
     docker:
@@ -64,12 +58,10 @@ jobs:
 
       - run:
           name: Prepare the environment.
-          command: |
-            bash .circleci/prepare.sh
+          command: bash .circleci/prepare.sh
       - run:
           name: Test.
-          command: |
-            venv/bin/python ./bin/run_tests.py
+          command: venv/bin/python ./bin/run_tests.py
 
 workflows:
   version: 2


### PR DESCRIPTION
While debugging #162 I ran into an issue that the commands on CircleCI were not showing any output:

<img width="1057" alt="Screenshot 2019-09-07 at 21 54 26" src="https://user-images.githubusercontent.com/314716/64480151-5fa0b280-d1ba-11e9-9c81-cbf71946b361.png">

This is due to the use of the multi-line script syntax, even though all test commands are one line long, so this PR changes the commands to be on one line, allowing the output to be seen.