### PR TITLE
Drop python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     # Linux Python 3
     - sudo: required
       language: python
-      python: 3.4
+      python: 3.5
       services: docker
       env: PYTHON=python
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,12 @@ What does it do?
 
 |   | macOS 10.6+ | manylinux i686 | manylinux x86_64 |  Windows 32bit | Windows 64bit |
 |---|---|---|---|---|---|
-| Python 2.7 | ✅ | ✅ | ✅ | ✅² | ✅² |
-| Python 3.4 | ✅ | ✅ | ✅ | ✅¹²| ✅¹²|
+| Python 2.7 | ✅ | ✅ | ✅ | ✅¹ | ✅¹ |
 | Python 3.5 | ✅ | ✅ | ✅ | ✅  | ✅  |
 | Python 3.6 | ✅ | ✅ | ✅ | ✅  | ✅  |
 | Python 3.7 | ✅ | ✅ | ✅ | ✅  | ✅  |
 
-> ¹ Not supported on Azure Pipelines 
->
-> ² Not supported on Travis
+> ¹ Not supported on Travis
 
 - Builds manylinux, macOS and Windows (32 and 64bit) wheels using Azure Pipelines, Travis CI, AppVeyor, and CircleCI
 - Bundles shared library dependencies on Linux and macOS through [auditwheel](https://github.com/pypa/auditwheel) and [delocate](https://github.com/matthew-brett/delocate)
@@ -58,7 +55,7 @@ Usage
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}
-  steps: 
+  steps:
     - task: UsePythonVersion@0
     - bash: |
         python -m pip install --upgrade pip
@@ -68,7 +65,7 @@ jobs:
       inputs: {pathtoPublish: 'wheelhouse'}
 - job: macos
   pool: {vmImage: 'macOS-10.13'}
-  steps: 
+  steps:
     - task: UsePythonVersion@0
     - bash: |
         python -m pip install --upgrade pip
@@ -78,7 +75,7 @@ jobs:
       inputs: {pathtoPublish: 'wheelhouse'}
 - job: windows
   pool: {vmImage: 'vs2017-win2016'}
-  steps: 
+  steps:
     - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x86}}
     - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x64}}
     - {task: UsePythonVersion@0, inputs: {versionSpec: '3.5', architecture: x86}}
@@ -110,7 +107,7 @@ jobs:
 
     ```yaml
     language: python
-    
+
     matrix:
       include:
         - sudo: required
@@ -126,7 +123,7 @@ jobs:
       - cibuildwheel --output-dir wheelhouse
     ```
 
-  To build on Windows too, add this matrix entry: 
+  To build on Windows too, add this matrix entry:
   ```yaml
     - os: windows
       language: shell
@@ -147,7 +144,7 @@ jobs:
         <img width="16" src="https://unpkg.com/simple-icons@latest/icons/apple.svg" />
         <img width="16" src="https://unpkg.com/simple-icons@latest/icons/linux.svg" />
     </summary>
-    
+
 - To build Linux and Mac wheels on CircleCI, create a `.circleci/config.yml` file in your repo,
 
   ```
@@ -213,14 +210,14 @@ jobs:
       - path: "wheelhouse\\*.whl"
         name: Wheels
     ```
-    
+
   AppVeyor will store the built wheels for you - you can access them from the project console. Alternatively, you may want to store them in the same place as the Travis CI build. See [AppVeyor deployment docs](https://www.appveyor.com/docs/deployment/) for more info, or see [Delivering to PyPI](#delivering-to-pypi) below.
-    
+
 </details>
 
 - Commit those files, enable building of your repo on Travis CI and AppVeyor, and push.
 
-All being well, you should get wheels delivered to you in a few minutes. 
+All being well, you should get wheels delivered to you in a few minutes.
 
 > ⚠️ Got an error? Check the [checklist](#it-didnt-work) below.
 
@@ -259,7 +256,7 @@ Options
 usage: cibuildwheel [-h] [--platform {auto,linux,macos,windows}]
                     [--output-dir OUTPUT_DIR] [--print-build-identifiers]
                     [project_dir]
-    
+
 Build wheels for all the platforms.
 
 positional arguments:
@@ -306,13 +303,13 @@ For `linux` you need Docker running, on Mac or Linux. For `macos`, you need a Ma
 
 Optional.
 
-Space-separated list of builds to build and skip. Each build has an identifier like `cp27-manylinux_x86_64` or `cp34-macosx_10_6_intel` - you can list specific ones to build and `cibuildwheel` will only build those, and/or list ones to skip and `cibuildwheel` won't try to build them.
+Space-separated list of builds to build and skip. Each build has an identifier like `cp27-manylinux_x86_64` or `cp35-macosx_10_6_intel` - you can list specific ones to build and `cibuildwheel` will only build those, and/or list ones to skip and `cibuildwheel` won't try to build them.
 
 When both options are specified, both conditions are applied and only builds with a tag that matches `CIBW_BUILD` and does not match `CIBW_SKIP` will be built.
 
 The format is `python_tag-platform_tag`. The tags are similar but not identical to the ones defined in [PEP 425](https://www.python.org/dev/peps/pep-0425/#details).
 
-Python tags look like `cp27` `cp34` `cp35` `cp36` `cp37`
+Python tags look like `cp27` `cp35` `cp36` `cp37`
 
 Platform tags look like `macosx_10_6_intel` `manylinux_x86_64` `manylinux_i686` `win32` `win_amd64`
 
@@ -326,7 +323,7 @@ Examples:
 - Skip building on Python 2.7 on all platforms: `CIBW_SKIP`:`cp27-*`
 - Skip Python 2.7 on Windows: `CIBW_SKIP`:`cp27-win*`
 - Skip Python 2.7 on 32-bit Windows: `CIBW_SKIP`:`cp27-win32`
-- Skip Python 3.4 and Python 3.5: `CIBW_SKIP`:`cp34-* cp35-*`
+- Skip Python 2.7 and Python 3.5: `CIBW_SKIP`:`cp27-* cp35-*`
 - Skip Python 3.6 on Linux: `CIBW_SKIP`:`cp36-manylinux*`
 - Only build on Python 3 and skip 32-bit builds: `CIBW_BUILD`:`cp3?-*` and `CIBW_SKIP`:`*-win32 *-manylinux_i686`
 
@@ -355,10 +352,10 @@ You must set this variable to pass variables to Linux builds (since they execute
 
 You can use `$PATH` syntax to insert other variables, or the `$(pwd)` syntax to insert the output of other shell commands.
 
-Example: `CFLAGS="-g -Wall" CXXFLAGS="-Wall"`  
-Example: `PATH=$PATH:/usr/local/bin`  
-Example: `BUILD_TIME="$(date)"`  
-Example: `PIP_EXTRA_INDEX_URL="https://pypi.myorg.com/simple"`  
+Example: `CFLAGS="-g -Wall" CXXFLAGS="-Wall"`
+Example: `PATH=$PATH:/usr/local/bin`
+Example: `BUILD_TIME="$(date)"`
+Example: `PIP_EXTRA_INDEX_URL="https://pypi.myorg.com/simple"`
 
 Platform-specific variants also available:
 `CIBW_ENVIRONMENT_MACOS` | `CIBW_ENVIRONMENT_WINDOWS` | `CIBW_ENVIRONMENT_LINUX`
@@ -378,11 +375,11 @@ If dependencies are required to build your wheel (for example if you include a h
 
 The active Python binary can be accessed using `python`, and pip with `pip`; `cibuildwheel` makes sure the right version of Python and pip will be executed. `{project}` can be used as a placeholder for the absolute path to the project's root.
 
-Example: `pip install .`  
-Example: `pip install pybind11`  
+Example: `pip install .`
+Example: `pip install pybind11`
 Example: `yum install -y libffi-dev && pip install .`
 
-Platform-specific variants also available:  
+Platform-specific variants also available:
  `CIBW_BEFORE_BUILD_MACOS` | `CIBW_BEFORE_BUILD_WINDOWS` | `CIBW_BEFORE_BUILD_LINUX`
 
 ***
@@ -400,8 +397,8 @@ Beware to specify a valid Docker image that can be used in the same way as the o
 
 Note that `auditwheel` detects the version of the `manylinux` standard in the Docker image through the `AUDITWHEEL_PLAT` environment variable, as `cibuildwheel` has no way of detecting the correct `--plat` command line argument to pass to `auditwheel` for a custom image. If a Docker image does not correctly set this `AUDITWHEEL_PLAT` environment variable, the `CIBW_ENVIRONMENT` option can be used to do so (e.g., `CIBW_ENVIRONMENT="manylinux2010_$(uname -m)"`).
 
-Example: `manylinux1`  
-Example: `dockcross/manylinux-x64`  
+Example: `manylinux1`
+Example: `dockcross/manylinux-x64`
 Example: `dockcross/manylinux-x86`
 
 ***
@@ -413,7 +410,7 @@ Optional.
 
 Shell command to run tests after the build. The wheel will be installed automatically and available for import from the tests. `{project}` can be used as a placeholder for the absolute path to the project's root and will be replaced by `cibuildwheel`.
 
-On Linux and Mac, the command runs in a shell, so you can write things like `cmd1 && cmd2`. 
+On Linux and Mac, the command runs in a shell, so you can write things like `cmd1 && cmd2`.
 
 Example: `nosetests {project}/tests`
 
@@ -429,7 +426,7 @@ Optional.
 
 Space-separated list of dependencies required for running the tests.
 
-Example: `pytest`  
+Example: `pytest`
 Example: `nose==1.3.7 moto==0.4.31`
 
 Platform-specific variants also available:
@@ -480,13 +477,13 @@ After you've built your wheels, you'll probably want to deliver them to PyPI.
 On your development machine, do the following...
 
 ```bash
-# Clear out your 'dist' folder. 
+# Clear out your 'dist' folder.
 rm -rf dist
 # Make a source distribution
 python setup.py sdist
 
 # 🏃🏻
-# Go and download your wheel files from wherever you put them. Put 
+# Go and download your wheel files from wherever you put them. Put
 # them all into the 'dist' folder.
 
 # Upload using 'twine' (you may need to 'pip install twine')
@@ -518,7 +515,7 @@ If your wheel didn't compile, check the list below for some debugging tips.
 Working examples
 ----------------
 
-Here are some repos that use cibuildwheel. 
+Here are some repos that use cibuildwheel.
 
 - [pyinstrument_cext](https://github.com/joerick/pyinstrument_cext)
 - [websockets](https://github.com/aaugustin/websockets)
@@ -536,7 +533,7 @@ Here are some repos that use cibuildwheel.
 Legal note
 ----------
 
-Since `cibuildwheel` runs the wheel through delocate or auditwheel, it might automatically bundle dynamically linked libraries from the build machine. 
+Since `cibuildwheel` runs the wheel through delocate or auditwheel, it might automatically bundle dynamically linked libraries from the build machine.
 
 It helps ensure that the library can run without any dependencies outside of the pip toolchain.
 
@@ -568,7 +565,7 @@ _26 May 2019_
 
 - ✨ Add support for building on Azure pipelines! This lets you build all
   Linux, Mac and Windows wheels on one service, so it promises to be the
-  easiest to set up! Check out the quickstart in the docs, or 
+  easiest to set up! Check out the quickstart in the docs, or
   [cibuildwheel-azure-example](https://github.com/joerick/cibuildwheel-azure-example)
   for an example project. (#126, #132)
 - 🛠 Internal change - the end-to-end test projects format was updated, so we
@@ -708,7 +705,7 @@ _11 June 2017_
 
 _13 April 2017_
 
-- ✨ Added `CIBW_SKIP` option, letting users explicitly skip a build 
+- ✨ Added `CIBW_SKIP` option, letting users explicitly skip a build
 - ✨ Added `CIBW_BEFORE_BUILD` option, letting users run a shell command before the build starts
 
 ### 0.1.3
@@ -750,7 +747,7 @@ Maintainers
 Credits
 -------
 
-`cibuildwheel` stands on the shoulders of giants. 
+`cibuildwheel` stands on the shoulders of giants.
 
 - ⭐️ @matthew-brett for [matthew-brett/multibuild](http://github.com/matthew-brett/multibuild) and [matthew-brett/delocate](http://github.com/matthew-brett/delocate)
 - @PyPA for the manylinux Docker images [pypa/manylinux](https://github.com/pypa/manylinux)

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -14,13 +14,11 @@ def get_python_configurations(build_selector):
     python_configurations = [
         PythonConfiguration(identifier='cp27-manylinux_x86_64', path='/opt/python/cp27-cp27m'),
         PythonConfiguration(identifier='cp27-manylinux_x86_64', path='/opt/python/cp27-cp27mu'),
-        PythonConfiguration(identifier='cp34-manylinux_x86_64', path='/opt/python/cp34-cp34m'),
         PythonConfiguration(identifier='cp35-manylinux_x86_64', path='/opt/python/cp35-cp35m'),
         PythonConfiguration(identifier='cp36-manylinux_x86_64', path='/opt/python/cp36-cp36m'),
         PythonConfiguration(identifier='cp37-manylinux_x86_64', path='/opt/python/cp37-cp37m'),
         PythonConfiguration(identifier='cp27-manylinux_i686', path='/opt/python/cp27-cp27m'),
         PythonConfiguration(identifier='cp27-manylinux_i686', path='/opt/python/cp27-cp27mu'),
-        PythonConfiguration(identifier='cp34-manylinux_i686', path='/opt/python/cp34-cp34m'),
         PythonConfiguration(identifier='cp35-manylinux_i686', path='/opt/python/cp35-cp35m'),
         PythonConfiguration(identifier='cp36-manylinux_i686', path='/opt/python/cp36-cp36m'),
         PythonConfiguration(identifier='cp37-manylinux_i686', path='/opt/python/cp37-cp37m'),

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -15,7 +15,6 @@ def get_python_configurations(build_selector):
     PythonConfiguration = namedtuple('PythonConfiguration', ['version', 'identifier', 'url'])
     python_configurations = [
         PythonConfiguration(version='2.7', identifier='cp27-macosx_10_6_intel', url='https://www.python.org/ftp/python/2.7.17/python-2.7.17-macosx10.6.pkg'),
-        PythonConfiguration(version='3.4', identifier='cp34-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.4.4/python-3.4.4-macosx10.6.pkg'),
         PythonConfiguration(version='3.5', identifier='cp35-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg'),
         PythonConfiguration(version='3.6', identifier='cp36-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.6.pkg'),
         PythonConfiguration(version='3.7', identifier='cp37-macosx_10_6_intel', url='https://www.python.org/ftp/python/3.7.5/python-3.7.5-macosx10.6.pkg'),
@@ -58,7 +57,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             # install
             call(['sudo', 'installer', '-pkg', '/tmp/Python.pkg', '-target', '/'])
             # patch open ssl
-            if config.version in ('3.4', '3.5'):
+            if config.version == '3.5':
                 call(['curl', '-fsSLo', '/tmp/python-patch.tar.gz', 'https://github.com/mayeut/patch-macos-python-openssl/releases/download/v1.0.2t/patch-macos-python-%s-openssl-v1.0.2t.tar.gz' % config.version])
                 call(['sudo', 'tar', '-C', '/Library/Frameworks/Python.framework/Versions/%s/' % config.version, '-xmf', '/tmp/python-patch.tar.gz'])
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -57,8 +57,6 @@ def get_python_configurations(build_selector):
     python_configurations = [
         PythonConfiguration(version='2.7.x', arch="32", identifier='cp27-win32', path='C:\\Python27', nuget_version="2.7.16"),
         PythonConfiguration(version='2.7.x', arch="64", identifier='cp27-win_amd64', path='C:\\Python27-x64', nuget_version="2.7.16"),
-        PythonConfiguration(version='3.4.x', arch="32", identifier='cp34-win32', path='C:\\Python34', nuget_version=None),
-        PythonConfiguration(version='3.4.x', arch="64", identifier='cp34-win_amd64', path='C:\\Python34-x64', nuget_version=None),
         PythonConfiguration(version='3.5.x', arch="32", identifier='cp35-win32', path='C:\\Python35', nuget_version="3.5.4"),
         PythonConfiguration(version='3.5.x', arch="64", identifier='cp35-win_amd64', path='C:\\Python35-x64', nuget_version="3.5.4"),
         PythonConfiguration(version='3.6.x', arch="32", identifier='cp36-win32', path='C:\\Python36', nuget_version="3.6.8"),
@@ -67,20 +65,14 @@ def get_python_configurations(build_selector):
         PythonConfiguration(version='3.7.x', arch="64", identifier='cp37-win_amd64', path='C:\\Python37-x64', nuget_version="3.7.4")
     ]
 
-    if IS_RUNNING_ON_AZURE:
-        # Python 3.4 isn't supported on Azure.
-        # See https://github.com/Microsoft/azure-pipelines-tasks/issues/9674
-        python_configurations = [c for c in python_configurations if c.version != '3.4.x']
-    
     if IS_RUNNING_ON_TRAVIS:
         # cannot install VCForPython27.msi which is needed for compiling C software
         # try with (and similar): msiexec /i VCForPython27.msi ALLUSERS=1 ACCEPT=YES /passive
-        # no easy and stable way fo installing python 3.4 
-        python_configurations = [c for c in python_configurations if c.version != '2.7.x' and c.version != '3.4.x']
+        python_configurations = [c for c in python_configurations if c.version != '2.7.x']
 
      # skip builds as required
     python_configurations = [c for c in python_configurations if build_selector(c.identifier)]
-   
+
     return python_configurations
 
 
@@ -109,7 +101,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
     if IS_RUNNING_ON_TRAVIS:
         # instal nuget as best way for provide python
         shell(["choco", "install", "nuget.commandline"])
-        # get pip fo this installation which not have. 
+        # get pip fo this installation which not have.
         get_pip_url = 'https://bootstrap.pypa.io/get-pip.py'
         get_pip_script = 'C:\\get-pip.py'
         shell(['curl', '-L', '-o', get_pip_script, get_pip_url])

--- a/test/04_build_skip/cibuildwheel_test.py
+++ b/test/04_build_skip/cibuildwheel_test.py
@@ -7,11 +7,11 @@ def test():
     # build the wheels
     utils.cibuildwheel_run(project_dir, add_env={
         'CIBW_BUILD': 'cp3?-*',
-        'CIBW_SKIP': 'cp34-*',
+        'CIBW_SKIP': 'cp37-*',
     })
 
-    # check that we got the right wheels. There should be no 2.7 or 3.4.
+    # check that we got the right wheels. There should be no 2.7 or 3.7.
     expected_wheels = [w for w in utils.expected_wheels('spam', '0.1.0')
-                       if ('-cp3' in w) and ('-cp34' not in w)]
+                       if ('-cp3' in w) and ('-cp37' not in w)]
     actual_wheels = os.listdir('wheelhouse')
     assert set(actual_wheels) == set(expected_wheels)

--- a/test/shared/utils.py
+++ b/test/shared/utils.py
@@ -26,14 +26,14 @@ def cibuildwheel_get_build_identifiers(project_path, env=None):
 
 def cibuildwheel_run(project_path, env=None, add_env=None):
     '''
-    Runs cibuildwheel as a subprocess, building the project at project_path. 
-    
+    Runs cibuildwheel as a subprocess, building the project at project_path.
+
     Uses the current Python interpreter.
     Configure settings using env.
     '''
     if env is None:
         env = os.environ.copy()
-    
+
     if add_env is not None:
         env.update(add_env)
 
@@ -51,25 +51,21 @@ def expected_wheels(package_name, package_version):
         templates = [
             '{package_name}-{package_version}-cp27-cp27m-manylinux1_x86_64.whl',
             '{package_name}-{package_version}-cp27-cp27mu-manylinux1_x86_64.whl',
-            '{package_name}-{package_version}-cp34-cp34m-manylinux1_x86_64.whl',
             '{package_name}-{package_version}-cp35-cp35m-manylinux1_x86_64.whl',
             '{package_name}-{package_version}-cp36-cp36m-manylinux1_x86_64.whl',
             '{package_name}-{package_version}-cp37-cp37m-manylinux1_x86_64.whl',
             '{package_name}-{package_version}-cp27-cp27m-manylinux2010_x86_64.whl',
             '{package_name}-{package_version}-cp27-cp27mu-manylinux2010_x86_64.whl',
-            '{package_name}-{package_version}-cp34-cp34m-manylinux2010_x86_64.whl',
             '{package_name}-{package_version}-cp35-cp35m-manylinux2010_x86_64.whl',
             '{package_name}-{package_version}-cp36-cp36m-manylinux2010_x86_64.whl',
             '{package_name}-{package_version}-cp37-cp37m-manylinux2010_x86_64.whl',
             '{package_name}-{package_version}-cp27-cp27m-manylinux1_i686.whl',
             '{package_name}-{package_version}-cp27-cp27mu-manylinux1_i686.whl',
-            '{package_name}-{package_version}-cp34-cp34m-manylinux1_i686.whl',
             '{package_name}-{package_version}-cp35-cp35m-manylinux1_i686.whl',
             '{package_name}-{package_version}-cp36-cp36m-manylinux1_i686.whl',
             '{package_name}-{package_version}-cp37-cp37m-manylinux1_i686.whl',
             '{package_name}-{package_version}-cp27-cp27m-manylinux2010_i686.whl',
             '{package_name}-{package_version}-cp27-cp27mu-manylinux2010_i686.whl',
-            '{package_name}-{package_version}-cp34-cp34m-manylinux2010_i686.whl',
             '{package_name}-{package_version}-cp35-cp35m-manylinux2010_i686.whl',
             '{package_name}-{package_version}-cp36-cp36m-manylinux2010_i686.whl',
             '{package_name}-{package_version}-cp37-cp37m-manylinux2010_i686.whl',
@@ -77,12 +73,10 @@ def expected_wheels(package_name, package_version):
     elif platform == 'windows':
         templates = [
             '{package_name}-{package_version}-cp27-cp27m-win32.whl',
-            '{package_name}-{package_version}-cp34-cp34m-win32.whl',
             '{package_name}-{package_version}-cp35-cp35m-win32.whl',
             '{package_name}-{package_version}-cp36-cp36m-win32.whl',
             '{package_name}-{package_version}-cp37-cp37m-win32.whl',
             '{package_name}-{package_version}-cp27-cp27m-win_amd64.whl',
-            '{package_name}-{package_version}-cp34-cp34m-win_amd64.whl',
             '{package_name}-{package_version}-cp35-cp35m-win_amd64.whl',
             '{package_name}-{package_version}-cp36-cp36m-win_amd64.whl',
             '{package_name}-{package_version}-cp37-cp37m-win_amd64.whl',
@@ -90,21 +84,17 @@ def expected_wheels(package_name, package_version):
     elif platform == 'macos':
         templates = [
             '{package_name}-{package_version}-cp27-cp27m-macosx_10_6_intel.whl',
-            '{package_name}-{package_version}-cp34-cp34m-macosx_10_6_intel.whl',
             '{package_name}-{package_version}-cp35-cp35m-macosx_10_6_intel.whl',
             '{package_name}-{package_version}-cp36-cp36m-macosx_10_6_intel.whl',
             '{package_name}-{package_version}-cp37-cp37m-macosx_10_6_intel.whl',
         ]
     else:
         raise Exception('unsupported platform')
-    
-    if IS_WINDOWS_RUNNING_ON_AZURE:
-        # Python 3.4 isn't supported on Azure.
-        templates = [t for t in templates if '-cp34-' not in t]
+
     if IS_WINDOWS_RUNNING_ON_TRAVIS:
         # Python 2.7 and 3.4 isn't supported on Travis.
-        templates = [t for t in templates if '-cp27-' not in t and '-cp34-' not in t]
-    
+        templates = [t for t in templates if '-cp27-' not in t]
+
     return [filename.format(package_name=package_name, package_version=package_version)
             for filename in templates]
 


### PR DESCRIPTION
Python 3.4 reached the end of its life on 16 March 2019.
It's about time to drop support for Python 3.4.

c.f. https://hugovk.github.io/drop-python/3.4/