### PR TITLE
Make sure build fails when test command fails

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -112,9 +112,9 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         # Run the tests from a different directory
                         pushd $HOME
                         sh -c {test_command}
-                        test_retcode=$(( $test_retcode || $? ))
                         popd
                     )
+                    test_retcode=$(( $test_retcode || $? ))
 
                     # clean up
                     rm -rf "$venv_dir"

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -117,7 +117,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         sh -c {test_command}
                         popd
                     )
-                    # exit if tests failed
+                    # exit if tests failed (needed for older bash versions)
                     if [ $? -ne 0 ]; then
                       exit 1;
                     fi

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -114,7 +114,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
                         # Run the tests from a different directory
                         pushd $HOME
-                        sh -o errexit -c {test_command}
+                        sh -c {test_command}
                         popd
                     )
                     # exit if tests failed

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -57,6 +57,8 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             mkdir /output
             cd /project
 
+            test_retcode=0
+
             {environment_exports}
 
             for PYBIN in {pybin_paths}; do
@@ -110,6 +112,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         # Run the tests from a different directory
                         pushd $HOME
                         sh -c {test_command}
+                        test_retcode=$(( $test_retcode || $? ))
                         popd
                     )
 
@@ -121,6 +124,8 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                 mv "$delocated_wheel" /output
                 chown {uid}:{gid} "/output/$(basename "$delocated_wheel")"
             done
+
+            exit $test_retcode
         '''.format(
             pybin_paths=' '.join(c.path+'/bin' for c in platform_configs),
             test_requires=' '.join(test_requires),


### PR DESCRIPTION
First of all, thank you for creating this project!

I'm running the latest version (master) to test my package in a virtualenv and noticed that on Linux the return code of the test isn't used. This means that the build continues even though the test command fails. This PR fixes this by keeping the return code of the test command and making that the return code of the bash script.

Note that this is not needed on mac or windows because they use ``subprocess.check_call``.