### PR TITLE
Add support for GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test cibuildwheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+        python_version: ['3.7']
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      name: Install Python ${{ matrix.python_version }}
+      with:
+        python-version: ${{ matrix.python_version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install -r requirements-dev.txt
+    - name: Install Visual C++ for Python 2.7
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        choco install vcpython27 -f -y
+    - name: Test cibuildwheel
+      run: |
+        python ./bin/run_tests.py

--- a/CI.md
+++ b/CI.md
@@ -1,10 +1,10 @@
 This is a summary of the Python versions and platforms covered by the different CI platforms:
 
-|          | 3.5              | 3.6              | 3.7                   | 3.8              |
-|----------|------------------|------------------|-----------------------|------------------|
-| Linux    | Travis CI        | CircleCI         | AppVeyor              | Azure Pipelines  |
-| macOS    | Azure Pipelines  | CircleCI         | Travis CI¹ / CircleCI | Azure Pipelines  |
-| Windows  | TravisCI         | Azure Pipelines  | AppVeyor              | Azure Pipelines  |
+|          | 3.5              | 3.6              | 3.7                                               | 3.8              |
+|----------|------------------|------------------|---------------------------------------------------|------------------|
+| Linux    | Travis CI        | CircleCI         | AppVeyor / GitHub Actions                         | Azure Pipelines  |
+| macOS    | Azure Pipelines  | CircleCI         | AppVeyor / Travis CI¹ / CircleCI / GitHub Actions | Azure Pipelines  |
+| Windows  | TravisCI         | Azure Pipelines  | AppVeyor / GitHub Actions                         | Azure Pipelines  |
 
 > ¹ Python version not really pinned, but dependent on the (default) version of image used.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ cibuildwheel
 
 Python wheels are great. Building them across **Mac, Linux, Windows**, on **multiple versions of Python**, is not.
 
-`cibuildwheel` is here to help. `cibuildwheel` runs on your CI server - currently it supports Azure Pipelines, Travis CI, AppVeyor, and CircleCI - and it builds and tests your wheels across all of your platforms.
+`cibuildwheel` is here to help. `cibuildwheel` runs on your CI server - currently it supports Azure Pipelines, Travis CI, AppVeyor, GitHub Actions and CircleCI - and it builds and tests your wheels across all of your platforms.
 
 
 What does it do?
@@ -35,13 +35,14 @@ What does it do?
 Usage
 -----
 
-`cibuildwheel` currently works on **Travis CI**, **Azure Pipelines** and **AppVeyor** to build wheels for all three supported platforms (Linux, macOS, Windows). On **CircleCI** Linux and macOS wheels can be built.
+`cibuildwheel` currently works on **Travis CI**, **Azure Pipelines**, **AppVeyor** and **GitHub Actions** to build wheels for all three supported platforms (Linux, macOS, Windows). On **CircleCI** Linux and macOS wheels can be built.
 
 |                 | Linux | macOS | Windows |
 |-----------------|-------|-------|---------|
 | Azure Pipelines | ✅    | ✅    | ✅      |
 | Travis CI       | ✅    | ✅    | ✅      |
 | AppVeyor        | ✅    | ✅    | ✅      |
+| GitHub Actions  | ✅    | ✅    | ✅      |
 | CircleCI        | ✅    | ✅    |         |
 
 `cibuildwheel` is not intended to run on your development machine. Because it uses system Python from Python.org it will try to install packages globally - not what you expect from a build tool! Instead, isolated CI services like Travis CI, CircleCI, Azure Pipelines and AppVeyor are ideal.

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -77,12 +77,12 @@ def main():
     if args.platform != 'auto':
         platform = args.platform
     else:
-        ci = strtobool(os.environ.get('CI', 'false')) or 'BITRISE_BUILD_NUMBER' in os.environ or 'AZURE_HTTP_USER_AGENT' in os.environ
+        ci = strtobool(os.environ.get('CI', 'false')) or 'BITRISE_BUILD_NUMBER' in os.environ or 'AZURE_HTTP_USER_AGENT' in os.environ or 'GITHUB_WORKFLOW' in os.environ
         if not ci:
             print('cibuildwheel: Unable to detect platform. cibuildwheel should run on your CI server, '
-                  'Travis CI, AppVeyor, Azure Pipelines and CircleCI are supported. You can run on your '
-                  'development machine or other CI providers using the --platform argument. Check --help '
-                  'output for more information.',
+                  'Travis CI, AppVeyor, Azure Pipelines, GitHub Actions and CircleCI are supported. You '
+                  'can run on your development machine or other CI providers using the --platform argument. '
+                  'Check --help output for more information.',
                   file=sys.stderr)
             exit(2)
         if sys.platform.startswith('linux'):

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -65,6 +65,19 @@ AppVeyor will store the built wheels for you - you can access them from the proj
 
 For more info on this config file, check out the [docs](https://www.appveyor.com/docs/).
 
+# GitHub Actions [linux/mac/windows] {: #github-actions}
+
+Using GitHub Actions, you can build all three platforms on the same service. Create a `./github/workflows/build.yml` file in your repo.
+
+> build.yml
+```yaml
+{% include "../examples/github-minimal.yml" %}
+```
+
+Commit this file, enable building of your repo on GitHub Actions, and push.
+
+For more info on this file, check out the [docs](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions).
+
 > ⚠️ Got an error? Check the [FAQ](faq.md).
 
 <script>

--- a/examples/github-minimal.yml
+++ b/examples/github-minimal.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Build wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      name: Install Python
+      with:
+        python-version: '3.7'
+
+    - name: Install cibuildwheel
+      run: |
+        python -m pip install cibuildwheel==1.2.0
+    - name: Install Visual C++ for Python 2.7
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        choco install vcpython27 -f -y
+    - name: Build wheel
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+    - uses: actions/upload-artifact@v1
+      with:
+        name: wheels
+        path: ./wheelhouse

--- a/unit_test/main_tests/main_platform_test.py
+++ b/unit_test/main_tests/main_platform_test.py
@@ -11,6 +11,7 @@ def test_unknown_platform_non_ci(monkeypatch, capsys):
     monkeypatch.delenv('CI', raising=False)
     monkeypatch.delenv('BITRISE_BUILD_NUMBER', raising=False)
     monkeypatch.delenv('AZURE_HTTP_USER_AGENT', raising=False)
+    monkeypatch.delenv('GITHUB_WORKFLOW', raising=False)
 
     with pytest.raises(SystemExit) as exit:
         main()


### PR DESCRIPTION
Draft:
- [x] basic support (linux, macOS, windows 3.6, 3.7, 3.8)
- [x] python 2.7 on windows
- [x] python 3.5 on windows
- [x] documentation update

Closes #159


Here's a summary of python versions / CI providers used to test `cibuildwheel` after this PR:

|               |2.7                          |3.5           |3.6          |3.7       |3.8    |
|---------|------------------|----------|---------|-------|------|
|windows| AppVeyor               |TravisCI  |               |GitHub|Azure|
|linux       | TravisCI + CircleCI|TravisCI  |CircleCI  |TravisCI + GitHub |Azure|
|macOS  |                    CircleCI|               |TravisCI |CircleCI + GitHub |Azure|