### PR TITLE
Tests cibuildwheel across different python versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,8 @@ jobs:
   pool: {vmImage: 'Ubuntu-18.04'}
   steps:
     - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.8'
     - bash: |
         python -m pip install -r requirements-dev.txt
         python ./bin/run_tests.py
@@ -11,6 +13,8 @@ jobs:
   pool: {vmImage: 'macOS-10.13'}
   steps:
     - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.8'
     - bash: |
         python -m pip install -r requirements-dev.txt
         python ./bin/run_tests.py
@@ -19,6 +23,8 @@ jobs:
   pool: {vmImage: 'vs2017-win2016'}
   steps:
     - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.8'
     - script: choco install vcpython27 -f -y
       displayName: Install Visual C++ for Python 2.7
     - bash: |

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ setup(
     package_data={
         'cibuildwheel': ['resources/*'],
     },
+    # Supported python versions
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     keywords='ci wheel packaging pypi travis appveyor macos linux windows',
     classifiers=[
         'Intended Audience :: Developers',

--- a/unit_test/environment_test.py
+++ b/unit_test/environment_test.py
@@ -1,3 +1,4 @@
+import os
 from cibuildwheel.environment import parse_environment
 
 
@@ -37,12 +38,15 @@ def test_inheritance():
 def test_shell_eval():
     environment_recipe = parse_environment('VAR="$(echo "a test" string)"')
 
+    env_copy = os.environ.copy()
+    env_copy.pop('VAR', None)
+
     environment_dict = environment_recipe.as_dictionary(
-        prev_environment={}
+        prev_environment=env_copy
     )
     environment_cmds = environment_recipe.as_shell_commands()
 
-    assert environment_dict == {'VAR': 'a test string'}
+    assert environment_dict['VAR'] == 'a test string'
     assert environment_cmds == ['export VAR="$(echo "a test" string)"']
 
 def test_shell_eval_and_env():


### PR DESCRIPTION
Fixes #198 

Here's a summary of python versions / CI providers used to test `cibuildwheel`:

|               |2.7                          |3.5           |3.6          |3.7|3.8    |
|---------|------------------|----------|---------|---|------|
|windows| AppVeyor               |AppVeyor|Travis CI|      |Azure|
|linux       | TravisCI + CircleCI|Travis CI  |CircleCI |      |Azure|
|macOS  |TravisCI + CircleCI|                  |TravisCI|CircleCI|Azure|