### PR TITLE
Remove macOS python2 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ matrix:
       services: docker
       env: PYTHON=python
 
-    # macOS Python 2
-    - os: osx
-      env: PYTHON=python2
-
     # macOS Python 3
     - os: osx
       env: PYTHON=python3


### PR DESCRIPTION
Testing with python2 driver for `cibuildwheel` is already done on CircleCI.
Removing it from Travis CI speeds-up testing without reducing coverage.

Here's a summary of python versions / CI providers used to test `cibuildwheel` after this PR:

|               |2.7                          |3.5           |3.6          |3.7|3.8    |
|---------|------------------|----------|---------|---|------|
|windows| AppVeyor               |AppVeyor|Travis CI|      |Azure|
|linux       | TravisCI + CircleCI|Travis CI  |CircleCI |      |Azure|
|macOS  |                    CircleCI|                  |TravisCI|CircleCI|Azure|