### PR TITLE
Rework platform detection to ignore CI provider.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ matrix:
     - os: windows
       language: shell
       before_install:
-       - choco install python3 --version 3.6.8 --no-progress -y
+       - choco install python3 --version 3.5.4 --no-progress -y
       install:
-       - C:\\Python36\\python -m pip install -r requirements-dev.txt
+       - C:\\Python35\\python -m pip install -r requirements-dev.txt
       script:
-       - C:\\Python36\\python ./bin/run_tests.py
+       - C:\\Python35\\python ./bin/run_tests.py
 
 install: $PYTHON -m pip install -r requirements-dev.txt
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,11 @@
-environment:
-  matrix:
-    - PYTHON: "C:\\Python27\\python.exe"
-    - PYTHON: "C:\\Python35\\python.exe"
+image:
+  - Ubuntu
+  - Visual Studio 2015
 
 build_script:
-  - "%PYTHON% -m pip install -r requirements-dev.txt"
-  # the '-u' flag is required so the output is in the correct order. 
+  - cmd: "C:\\Python27\\python.exe -m pip install -r requirements-dev.txt"
+  - sh: "${HOME}/.localpython3.7.4/bin/python3 -m pip install -r requirements-dev.txt"
+  # the '-u' flag is required so the output is in the correct order.
   # See https://github.com/joerick/cibuildwheel/pull/24 for more info.
-  - "%PYTHON% -u ./bin/run_tests.py"
+  - cmd: "C:\\Python27\\python.exe -u ./bin/run_tests.py"
+  - sh: "${HOME}/.localpython3.7.4/bin/python3 ./bin/run_tests.py"

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -38,7 +38,7 @@ def main():
                               'script is going to automatically install MacPython on your system, '
                               'so don\'t run on your development machine. For "windows", you need to '
                               'run in Windows, and it will build and test for all versions of '
-                              'Python at C:\\PythonXX[-x64]. Default: auto.'))
+                              'Python. Default: auto.'))
     parser.add_argument('--output-dir',
                         default=os.environ.get('CIBW_OUTPUT_DIR', 'wheelhouse'),
                         help='Destination folder for the wheels.')
@@ -59,35 +59,15 @@ def main():
     if args.platform != 'auto':
         platform = args.platform
     else:
-        platform = None
-
-        if os.environ.get('TRAVIS_OS_NAME') == 'linux':
+        if sys.platform.startswith('linux'):
             platform = 'linux'
-        elif os.environ.get('TRAVIS_OS_NAME') == 'osx':
+        elif sys.platform == 'darwin':
             platform = 'macos'
-        elif os.environ.get('TRAVIS_OS_NAME') == 'windows':
+        elif sys.platform == 'win32':
             platform = 'windows'
-        elif 'APPVEYOR' in os.environ:
-            platform = 'windows'
-        elif 'BITRISE_BUILD_NUMBER' in os.environ:
-            platform = 'macos'
-        elif os.environ.get('CIRCLECI'):
-            if sys.platform.startswith('linux'):
-                platform = 'linux'
-            elif sys.platform.startswith('darwin'):
-                platform = 'macos'
-        elif 'AZURE_HTTP_USER_AGENT' in os.environ:
-            if os.environ['AGENT_OS'] == 'Linux':
-                platform = 'linux'
-            elif os.environ['AGENT_OS'] == 'Darwin':
-                platform = 'macos'
-            elif os.environ['AGENT_OS'] == 'Windows_NT':
-                platform = 'windows'
 
         if platform is None:
-            print('cibuildwheel: Unable to detect platform. cibuildwheel should run on your CI server, '
-                  'Travis CI, AppVeyor, and CircleCI are supported. You can run on your development '
-                  'machine using the --platform argument. Check --help output for more '
+            print('cibuildwheel: Unable to detect platform. Check --help output for more '
                   'information.',
                   file=sys.stderr)
             exit(2)

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -24,6 +24,12 @@ def get_option_from_environment(option_name, platform=None, default=None):
     return os.environ.get(option_name, default)
 
 
+def strtobool(val):
+    if val.lower() in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    return False
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Build wheels for all the platforms.',
@@ -59,16 +65,19 @@ def main():
     if args.platform != 'auto':
         platform = args.platform
     else:
-        if sys.platform.startswith('linux'):
-            platform = 'linux'
-        elif sys.platform == 'darwin':
-            platform = 'macos'
-        elif sys.platform == 'win32':
-            platform = 'windows'
-
+        ci = strtobool(os.environ.get('CI', 'false')) or 'BITRISE_BUILD_NUMBER' in os.environ or 'AZURE_HTTP_USER_AGENT' in os.environ
+        if ci:
+            if sys.platform.startswith('linux'):
+                platform = 'linux'
+            elif sys.platform == 'darwin':
+                platform = 'macos'
+            elif sys.platform == 'win32':
+                platform = 'windows'
         if platform is None:
-            print('cibuildwheel: Unable to detect platform. Check --help output for more '
-                  'information.',
+            print('cibuildwheel: Unable to detect platform. cibuildwheel should run on your CI server, '
+                  'Travis CI, AppVeyor, Azure Pipelines and CircleCI are supported. You can run on your '
+                  'development machine or other CI providers using the --platform argument. Check --help '
+                  'output for more information.',
                   file=sys.stderr)
             exit(2)
 


### PR DESCRIPTION
CI provider is now mostly irrelevant (#180), rework platform detection with that in mind.
Run linux test in AppVeyor.

Fixes #146 

Here's a summary of python versions / CI providers used to test `cibuildwheel` after this PR:

|               |2.7                          |3.5           |3.6          |3.7       |3.8    |
|---------|------------------|----------|---------|-------|------|
|windows| AppVeyor               |TravisCI  |               |             |Azure|
|linux       | TravisCI + CircleCI|TravisCI  |CircleCI  |TravisCI|Azure|
|macOS  |                    CircleCI|               |TravisCI |CircleCI |Azure|