### PR TITLE
Avoid script location warnings on Windows

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -92,9 +92,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
         call(['python', get_pip_script, '--no-setuptools', '--no-wheel'], env=env)
         assert os.path.exists(os.path.join(installation_bin_path, 'pip'))
         call(['pip', '--version'], env=env)
-        call(['pip', 'install', '--upgrade', 'setuptools'], env=env)
-        call(['pip', 'install', 'wheel'], env=env)
-        call(['pip', 'install', 'delocate'], env=env)
+        call(['pip', 'install', '--upgrade', 'setuptools', 'wheel', 'delocate'], env=env)
 
         # setup dirs
         if os.path.exists('/tmp/built_wheel'):

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -63,6 +63,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                 call(['sudo', 'tar', '-C', '/Library/Frameworks/Python.framework/Versions/%s/' % config.version, '-xmf', '/tmp/python-patch.tar.gz'])
 
         installation_bin_path = '/Library/Frameworks/Python.framework/Versions/{}/bin'.format(config.version)
+        assert os.path.exists(os.path.join(installation_bin_path, 'python3' if config.version[0] == '3' else 'python'))
 
         # Python bin folders on Mac don't symlink python3 to python, so we do that
         # so `python` and `pip` always point to the active configuration.
@@ -89,6 +90,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
         # install pip & wheel
         call(['python', get_pip_script, '--no-setuptools', '--no-wheel'], env=env)
+        assert os.path.exists(os.path.join(installation_bin_path, 'pip'))
         call(['pip', '--version'], env=env)
         call(['pip', 'install', '--upgrade', 'setuptools'], env=env)
         call(['pip', 'install', 'wheel'], env=env)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -118,9 +118,9 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
         env = environment.as_dictionary(prev_environment=env)
 
         # for the logs - check we're running the right version of python
-        shell(['where', 'python'], env=env)
-        shell(['python', '--version'], env=env)
-        shell(['python', '-c', '"import struct; print(struct.calcsize(\'P\') * 8)\"'], env=env)
+        simple_shell(['where', 'python'], env=env)
+        simple_shell(['python', '--version'], env=env)
+        simple_shell(['python', '-c', '"import struct; print(struct.calcsize(\'P\') * 8)\"'], env=env)
 
         # make sure pip is installed
         if not os.path.exists(os.path.join(config_python_path, 'Scripts', 'pip.exe')):
@@ -128,10 +128,10 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
         assert os.path.exists(os.path.join(config_python_path, 'Scripts', 'pip.exe'))
 
         # prepare the Python environment
-        shell(['python', '-m', 'pip', 'install', '--upgrade', 'pip'], env=env)
-        shell(['pip', '--version'], env=env)
-        shell(['pip', 'install', '--upgrade', 'setuptools'], env=env)
-        shell(['pip', 'install', 'wheel'], env=env)
+        simple_shell(['python', '-m', 'pip', 'install', '--upgrade', 'pip'], env=env)
+        simple_shell(['pip', '--version'], env=env)
+        simple_shell(['pip', 'install', '--upgrade', 'setuptools'], env=env)
+        simple_shell(['pip', 'install', 'wheel'], env=env)
 
         # setup dirs
         if os.path.exists(built_wheel_dir):

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -124,14 +124,13 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
         # make sure pip is installed
         if not os.path.exists(os.path.join(config_python_path, 'Scripts', 'pip.exe')):
-            simple_shell([os.path.join(config_python_path, 'python.exe'), get_pip_script], env=env)
+            simple_shell(['python', get_pip_script], env=env)
         assert os.path.exists(os.path.join(config_python_path, 'Scripts', 'pip.exe'))
 
         # prepare the Python environment
         simple_shell(['python', '-m', 'pip', 'install', '--upgrade', 'pip'], env=env)
         simple_shell(['pip', '--version'], env=env)
-        simple_shell(['pip', 'install', '--upgrade', 'setuptools'], env=env)
-        simple_shell(['pip', 'install', 'wheel'], env=env)
+        simple_shell(['pip', 'install', '--upgrade', 'setuptools', 'wheel'], env=env)
 
         # setup dirs
         if os.path.exists(built_wheel_dir):

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -100,22 +100,13 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
     python_configurations = get_python_configurations(build_selector)
     for config in python_configurations:
+        # install Python
         config_python_path = get_python_path(config)
         simple_shell([nuget, "install"] + get_nuget_args(config))
-        if not os.path.exists(os.path.join(config_python_path, 'Scripts', 'pip.exe')):
-            simple_shell([os.path.join(config_python_path, 'python.exe'), get_pip_script ])
-
-        # check python & pip exist for this configuration
         assert os.path.exists(os.path.join(config_python_path, 'python.exe'))
-        assert os.path.exists(os.path.join(config_python_path, 'Scripts', 'pip.exe'))
 
-        # setup dirs
-        if os.path.exists(built_wheel_dir):
-            shutil.rmtree(built_wheel_dir)
-        os.makedirs(built_wheel_dir)
-
+        # set up PATH and environment variables for run_with_env
         env = os.environ.copy()
-        # set up environment variables for run_with_env
         env['PYTHON_VERSION'] = config.version
         env['PYTHON_ARCH'] = config.arch
         env['PATH'] = os.pathsep.join([
@@ -123,16 +114,29 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             os.path.join(config_python_path, 'Scripts'),
             env['PATH']
         ])
+        # update env with results from CIBW_ENVIRONMENT
         env = environment.as_dictionary(prev_environment=env)
 
         # for the logs - check we're running the right version of python
+        shell(['where', 'python'], env=env)
         shell(['python', '--version'], env=env)
         shell(['python', '-c', '"import struct; print(struct.calcsize(\'P\') * 8)\"'], env=env)
 
+        # make sure pip is installed
+        if not os.path.exists(os.path.join(config_python_path, 'Scripts', 'pip.exe')):
+            simple_shell([os.path.join(config_python_path, 'python.exe'), get_pip_script], env=env)
+        assert os.path.exists(os.path.join(config_python_path, 'Scripts', 'pip.exe'))
+
         # prepare the Python environment
         shell(['python', '-m', 'pip', 'install', '--upgrade', 'pip'], env=env)
+        shell(['pip', '--version'], env=env)
         shell(['pip', 'install', '--upgrade', 'setuptools'], env=env)
         shell(['pip', 'install', 'wheel'], env=env)
+
+        # setup dirs
+        if os.path.exists(built_wheel_dir):
+            shutil.rmtree(built_wheel_dir)
+        os.makedirs(built_wheel_dir)
 
         # run the before_build command
         if before_build:


### PR DESCRIPTION
This should get rid of the "WARNING: The scripts [...] are installed in '...' which is not on PATH." warnings (e.g., https://travis-ci.org/joerick/cibuildwheel/jobs/610081892#L636).

Moreover, since macOS and Windows had different ordering of the steps setting up the build environment (e.g., `CIBW_ENVIRONMENT` before or after the installation of `pip`), I've reordered the steps on Windows. Is this the correct order?

Alternatively, we could just silence the warnings with `--no-warn-script-location`, but fixing this (and keeping the warnings when they are relevant!) seems like a better solution.

Besides that, when do we want to use `simple_shell` vs. `shell`, @mayeut?