### PR TITLE
Add `CIBW_REPAIR_WHEEL_COMMAND` env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ Options
 |   | [`CIBW_BUILD`](https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip)  [`CIBW_SKIP`](https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip)  | Choose the Python versions to build |
 | **Build environment** | [`CIBW_ENVIRONMENT`](https://cibuildwheel.readthedocs.io/en/stable/options/#environment)  | Set environment variables needed during the build |
 |   | [`CIBW_BEFORE_BUILD`](https://cibuildwheel.readthedocs.io/en/stable/options/#before-build)  | Execute a shell command preparing each wheel's build |
+|   | [`CIBW_REPAIR_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#repair-command)  | Execute a shell command to repair each (non-pure Python) built wheel |
 |   | [`CIBW_MANYLINUX_X86_64_IMAGE`](https://cibuildwheel.readthedocs.io/en/stable/options/#manylinux-image)  [`CIBW_MANYLINUX_I686_IMAGE`](https://cibuildwheel.readthedocs.io/en/stable/options/#manylinux-image)  | Specify alternative manylinux docker images |
-| **Testing** | [`CIBW_TEST_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-command)  | Execute a shell command to test all built wheels |
+| **Testing** | [`CIBW_TEST_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-command)  | Execute a shell command to test each built wheel |
 |   | [`CIBW_TEST_REQUIRES`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-requires)  | Install Python dependencies before running the tests |
 |   | [`CIBW_TEST_EXTRAS`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-extras)  | Install your wheel for testing using extras_require |
 | **Other** | [`CIBW_BUILD_VERBOSITY`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-extras)  | Increase/decrease the output of pip wheel |
@@ -122,7 +123,7 @@ Here are some repos that use cibuildwheel.
 Legal note
 ----------
 
-Since `cibuildwheel` runs the wheel through delocate or auditwheel, it might automatically bundle dynamically linked libraries from the build machine.
+Since `cibuildwheel` repairs the wheel with `delocate` or `auditwheel`, it might automatically bundle dynamically linked libraries from the build machine.
 
 It helps ensure that the library can run without any dependencies outside of the pip toolchain.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Options
 |   | [`CIBW_BUILD`](https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip)  [`CIBW_SKIP`](https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip)  | Choose the Python versions to build |
 | **Build environment** | [`CIBW_ENVIRONMENT`](https://cibuildwheel.readthedocs.io/en/stable/options/#environment)  | Set environment variables needed during the build |
 |   | [`CIBW_BEFORE_BUILD`](https://cibuildwheel.readthedocs.io/en/stable/options/#before-build)  | Execute a shell command preparing each wheel's build |
-|   | [`CIBW_REPAIR_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#repair-command)  | Execute a shell command to repair each (non-pure Python) built wheel |
+|   | [`CIBW_REPAIR_WHEEL_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#repair-wheel-command)  | Execute a shell command to repair each (non-pure Python) built wheel |
 |   | [`CIBW_MANYLINUX_X86_64_IMAGE`](https://cibuildwheel.readthedocs.io/en/stable/options/#manylinux-image)  [`CIBW_MANYLINUX_I686_IMAGE`](https://cibuildwheel.readthedocs.io/en/stable/options/#manylinux-image)  | Specify alternative manylinux docker images |
 | **Testing** | [`CIBW_TEST_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-command)  | Execute a shell command to test each built wheel |
 |   | [`CIBW_TEST_REQUIRES`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-requires)  | Install Python dependencies before running the tests |

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -89,6 +89,13 @@ def main():
     before_build = get_option_from_environment('CIBW_BEFORE_BUILD', platform=platform)
     build_verbosity = get_option_from_environment('CIBW_BUILD_VERBOSITY', platform=platform, default='')
     build_config, skip_config = os.environ.get('CIBW_BUILD', '*'), os.environ.get('CIBW_SKIP', '')
+    if platform == 'linux':
+        repair_command_default = 'auditwheel repair -w {dest_dir} {wheel}'
+    elif platform == 'macos':
+        repair_command_default = 'delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} {wheel}'
+    else:
+        repair_command_default = ''
+    repair_command = get_option_from_environment('CIBW_REPAIR_COMMAND', platform=platform, default=repair_command_default)
     environment_config = get_option_from_environment('CIBW_ENVIRONMENT', platform=platform, default='')
 
     if test_extras:
@@ -130,6 +137,7 @@ def main():
         before_build=before_build,
         build_verbosity=build_verbosity,
         build_selector=build_selector,
+        repair_command=repair_command,
         environment=environment,
     )
 

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -95,7 +95,7 @@ def main():
         repair_command_default = 'delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} {wheel}'
     else:
         repair_command_default = ''
-    repair_command = get_option_from_environment('CIBW_REPAIR_COMMAND', platform=platform, default=repair_command_default)
+    repair_command = get_option_from_environment('CIBW_REPAIR_WHEEL_COMMAND', platform=platform, default=repair_command_default)
     environment_config = get_option_from_environment('CIBW_ENVIRONMENT', platform=platform, default='')
 
     if test_extras:

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -79,7 +79,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                     # pure Python wheel or empty repair command
                     mv "$built_wheel" /tmp/repaired_wheels
                 else
-                    built_wheel=$built_wheel sh -c {repair_command}
+                    sh -c {repair_command} repair_command "$built_wheel"
                 fi
                 repaired_wheels=(/tmp/repaired_wheels/*.whl)
 
@@ -140,7 +140,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             ),
             build_verbosity_flag=' '.join(get_build_verbosity_extra_flags(build_verbosity)),
             repair_command=shlex_quote(
-                prepare_command(repair_command, wheel='"$built_wheel"', dest_dir='/tmp/repaired_wheels') if repair_command else ''
+                prepare_command(repair_command, wheel='"$1"', dest_dir='/tmp/repaired_wheels') if repair_command else ''
             ),
             environment_exports='\n'.join(environment.as_shell_commands()),
             uid=os.getuid(),

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -25,7 +25,12 @@ def get_python_configurations(build_selector):
     return [c for c in python_configurations if build_selector(c.identifier)]
 
 
-def build(project_dir, output_dir, test_command, test_requires, test_extras, before_build, build_verbosity, build_selector, environment):
+def build(project_dir, output_dir, test_command, test_requires, test_extras, before_build, build_verbosity, build_selector, repair_command, environment):
+    abs_project_dir = os.path.abspath(project_dir)
+    temp_dir = tempfile.mkdtemp(prefix='cibuildwheel')
+    built_wheel_dir = os.path.join(temp_dir, 'built_wheel')
+    repaired_wheel_dir = os.path.join(temp_dir, 'repaired_wheel')
+
     python_configurations = get_python_configurations(build_selector)
     get_pip_url = 'https://bootstrap.pypa.io/get-pip.py'
     get_pip_script = '/tmp/get-pip.py'
@@ -43,8 +48,6 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             print('+ ' + ' '.join(shlex_quote(a) for a in args))
 
         return subprocess.check_call(args, env=env, cwd=cwd, shell=shell)
-
-    abs_project_dir = os.path.abspath(project_dir)
 
     # get latest pip once and for all
     call(['curl', '-L', '-o', get_pip_script, get_pip_url])
@@ -94,32 +97,29 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
         call(['pip', '--version'], env=env)
         call(['pip', 'install', '--upgrade', 'setuptools', 'wheel', 'delocate'], env=env)
 
-        # setup dirs
-        if os.path.exists('/tmp/built_wheel'):
-            shutil.rmtree('/tmp/built_wheel')
-        os.makedirs('/tmp/built_wheel')
-        if os.path.exists('/tmp/delocated_wheel'):
-            shutil.rmtree('/tmp/delocated_wheel')
-        os.makedirs('/tmp/delocated_wheel')
-
         # run the before_build command
         if before_build:
             before_build_prepared = prepare_command(before_build, project=abs_project_dir)
             call(before_build_prepared, env=env, shell=True)
 
         # build the wheel
-        call(['pip', 'wheel', abs_project_dir, '-w', '/tmp/built_wheel', '--no-deps'] + get_build_verbosity_extra_flags(build_verbosity), env=env)
-        built_wheel = glob('/tmp/built_wheel/*.whl')[0]
+        if os.path.exists(built_wheel_dir):
+            shutil.rmtree(built_wheel_dir)
+        os.makedirs(built_wheel_dir)
+        call(['pip', 'wheel', abs_project_dir, '-w', built_wheel_dir, '--no-deps'] + get_build_verbosity_extra_flags(build_verbosity), env=env)
+        built_wheel = glob(os.path.join(built_wheel_dir, '*.whl'))[0]
 
-        if built_wheel.endswith('none-any.whl'):
-            # pure python wheel - just move
-            shutil.move(built_wheel, '/tmp/delocated_wheel')
+        # repair the wheel
+        if os.path.exists(repaired_wheel_dir):
+            shutil.rmtree(repaired_wheel_dir)
+        os.makedirs(repaired_wheel_dir)
+        if built_wheel.endswith('none-any.whl') or not repair_command:
+            # pure Python wheel or empty repair command
+            shutil.move(built_wheel, repaired_wheel_dir)
         else:
-            # list the dependencies
-            call(['delocate-listdeps', built_wheel], env=env)
-            # rebuild the wheel with shared libraries included and place in output dir
-            call(['delocate-wheel', '-w', '/tmp/delocated_wheel', built_wheel], env=env)
-        delocated_wheel = glob('/tmp/delocated_wheel/*.whl')[0]
+            repair_command_prepared = prepare_command(repair_command, wheel=built_wheel, dest_dir=repaired_wheel_dir)
+            call(repair_command_prepared, env=env, shell=True)
+        repaired_wheel = glob(os.path.join(repaired_wheel_dir, '*.whl'))[0]
 
         if test_command:
             # set up a virtual environment to install and test from, to make sure
@@ -141,7 +141,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             call(['which', 'python'], env=virtualenv_env)
 
             # install the wheel
-            call(['pip', 'install', delocated_wheel + test_extras], env=virtualenv_env)
+            call(['pip', 'install', repaired_wheel + test_extras], env=virtualenv_env)
 
             # test the wheel
             if test_requires:
@@ -157,5 +157,5 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             shutil.rmtree(venv_dir)
 
         # we're all done here; move it to output (overwrite existing)
-        dst = os.path.join(output_dir, os.path.basename(delocated_wheel))
-        shutil.move(delocated_wheel, dst)
+        dst = os.path.join(output_dir, os.path.basename(repaired_wheel))
+        shutil.move(repaired_wheel, dst)

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -2,14 +2,14 @@ from fnmatch import fnmatch
 import warnings
 
 
-def prepare_command(command, project):
+def prepare_command(command, **kwargs):
     '''
-    Preprocesses a command by expanding variables like {project}.
+    Preprocesses a command by expanding variables like {python}.
 
-    For example, used in the test_command option, to specify the path to the
-    tests directory.
+    For example, used in the test_command option to specify the path to the
+    project's root.
     '''
-    return command.format(python='python', pip='pip', project=project)
+    return command.format(python='python', pip='pip', **kwargs)
 
 
 def get_build_verbosity_extra_flags(level):

--- a/docs/options.md
+++ b/docs/options.md
@@ -148,6 +148,9 @@ You must set this variable to pass variables to Linux builds (since they execute
 
 You can use `$PATH` syntax to insert other variables, or the `$(pwd)` syntax to insert the output of other shell commands.
 
+Platform-specific variants also available:<br/>
+`CIBW_ENVIRONMENT_MACOS` | `CIBW_ENVIRONMENT_WINDOWS` | `CIBW_ENVIRONMENT_LINUX`
+
 #### Examples
 ```yaml
 # Set some compiler flags
@@ -162,9 +165,6 @@ CIBW_ENVIRONMENT: "BUILD_TIME=$(date)"
 # Supply options to `pip` to affect how it downloads dependencies
 CIBW_ENVIRONMENT: "PIP_EXTRA_INDEX_URL=https://pypi.myorg.com/simple"
 ```
-
-Platform-specific variants also available:<br/>
-`CIBW_ENVIRONMENT_MACOS` | `CIBW_ENVIRONMENT_WINDOWS` | `CIBW_ENVIRONMENT_LINUX`
 
 !!! note
     `cibuildwheel` always defines the environment variable `CIBUILDWHEEL=1`. This can be useful for [building wheels with optional extensions](faq.md#building-packages-with-optional-c-extensions).
@@ -181,6 +181,9 @@ The active Python binary can be accessed using `python`, and pip with `pip`; `ci
 
 On Linux and macOS, the command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
+Platform-specific variants also available:<br/>
+ `CIBW_BEFORE_BUILD_MACOS` | `CIBW_BEFORE_BUILD_WINDOWS` | `CIBW_BEFORE_BUILD_LINUX`
+
 #### Examples
 ```yaml
 # install your project and dependencies before building
@@ -192,9 +195,6 @@ CIBW_BEFORE_BUILD: pip install pybind11
 # chain commands using &&
 CIBW_BEFORE_BUILD: yum install -y libffi-dev && pip install .
 ```
-
-Platform-specific variants also available:<br/>
- `CIBW_BEFORE_BUILD_MACOS` | `CIBW_BEFORE_BUILD_WINDOWS` | `CIBW_BEFORE_BUILD_LINUX`
 
 
 ### `CIBW_REPAIR_WHEEL_COMMAND` {: #repair-wheel-command}
@@ -216,6 +216,9 @@ The following placeholders must be used inside the command and will be replaced 
 
 On Linux and macOS, the command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
+Platform-specific variants also available:<br/>
+`CIBW_REPAIR_WHEEL_COMMAND_MACOS` | `CIBW_REPAIR_WHEEL_COMMAND_WINDOWS` | `CIBW_REPAIR_WHEEL_COMMAND_LINUX`
+
 #### Examples
 
 ```yaml
@@ -225,9 +228,6 @@ CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
 # pass the `--lib-sdir .` flag to auditwheel on Linux
 CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --lib-sdir . -w {dest_dir} {wheel}"
 ```
-
-Platform-specific variants also available:<br/>
-`CIBW_REPAIR_WHEEL_COMMAND_MACOS` | `CIBW_REPAIR_WHEEL_COMMAND_WINDOWS` | `CIBW_REPAIR_WHEEL_COMMAND_LINUX`
 
 
 ### `CIBW_MANYLINUX_X86_64_IMAGE`, `CIBW_MANYLINUX_I686_IMAGE` {: #manylinux-image}
@@ -262,6 +262,9 @@ Shell command to run tests after the build. The wheel will be installed automati
 
 On Linux and macOS, the command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
+Platform-specific variants also available:<br/>
+`CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
+
 #### Examples
 
 ```yaml
@@ -272,14 +275,14 @@ CIBW_TEST_COMMAND: nosetests {project}/tests
 CIBW_TEST_COMMAND: nosetests {project}/tests
 ```
 
-Platform-specific variants also available:<br/>
-`CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
-
 
 ### `CIBW_TEST_REQUIRES` {: #test-requires}
 > Install Python dependencies before running the tests
 
 Space-separated list of dependencies required for running the tests.
+
+Platform-specific variants also available:<br/>
+`CIBW_TEST_REQUIRES_MACOS` | `CIBW_TEST_REQUIRES_WINDOWS` | `CIBW_TEST_REQUIRES_LINUX`
 
 #### Examples
 
@@ -291,8 +294,6 @@ CIBW_TEST_REQUIRES: pytest
 CIBW_TEST_REQUIRES: nose==1.3.7 moto==0.4.31
 ```
 
-Platform-specific variants also available:<br/>
-`CIBW_TEST_REQUIRES_MACOS` | `CIBW_TEST_REQUIRES_WINDOWS` | `CIBW_TEST_REQUIRES_LINUX`
 
 ### `CIBW_TEST_EXTRAS` {: #test-extras}
 > Install your wheel for testing using `extras_require`
@@ -304,6 +305,9 @@ tests. This can be used to avoid having to redefine test dependencies in
 `CIBW_TEST_REQUIRES` if they are already defined in `setup.py` or
 `setup.cfg`.
 
+Platform-specific variants also available:<br/>
+`CIBW_TEST_EXTRAS_MACOS` | `CIBW_TEST_EXTRAS_WINDOWS` | `CIBW_TEST_EXTRAS_LINUX`
+
 #### Examples
 
 ```yaml
@@ -311,8 +315,6 @@ tests. This can be used to avoid having to redefine test dependencies in
 CIBW_TEST_EXTRAS: test,qt
 ```
 
-Platform-specific variants also available:<br/>
-`CIBW_TEST_EXTRAS_MACOS` | `CIBW_TEST_EXTRAS_WINDOWS` | `CIBW_TEST_EXTRAS_LINUX`
 
 ## Other
 
@@ -321,6 +323,9 @@ Platform-specific variants also available:<br/>
 
 An number from 1 to 3 to increase the level of verbosity (corresponding to invoking pip with `-v`, `-vv`, and `-vvv`), between -1 and -3 (`-q`, `-qq`, and `-qqq`), or just 0 (default verbosity). These flags are useful while debugging a build when the output of the actual build invoked by `pip wheel` is required.
 
+Platform-specific variants also available:<br/>
+`CIBW_BUILD_VERBOSITY_MACOS` | `CIBW_BUILD_VERBOSITY_WINDOWS` | `CIBW_BUILD_VERBOSITY_LINUX`
+
 #### Examples
 
 ```yaml
@@ -328,8 +333,6 @@ An number from 1 to 3 to increase the level of verbosity (corresponding to invok
 CIBW_BUILD_VERBOSITY: 1
 ```
 
-Platform-specific variants also available:<br/>
-`CIBW_BUILD_VERBOSITY_MACOS` | `CIBW_BUILD_VERBOSITY_WINDOWS` | `CIBW_BUILD_VERBOSITY_LINUX`
 
 ## Command line options
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -4,7 +4,7 @@
 
 ## Setting options
 
-cibuildwheel is configured using environment variables, that can be set using 
+cibuildwheel is configured using environment variables, that can be set using
 your CI config.
 
 For example, to configure cibuildwheel to run tests, add the following YAML to
@@ -120,7 +120,7 @@ CIBW_SKIP: "*-win32 *-manylinux_i686"
     font-size: 90%;
     white-space: nowrap;
   }
-  .rst-content .build-id-table-marker + table td, 
+  .rst-content .build-id-table-marker + table td,
   .rst-content .build-id-table-marker + table th {
     padding: 4px 4px;
   }
@@ -163,7 +163,7 @@ CIBW_ENVIRONMENT: "BUILD_TIME=$(date)"
 CIBW_ENVIRONMENT: "PIP_EXTRA_INDEX_URL=https://pypi.myorg.com/simple"
 ```
 
-Platform-specific variants also available:  
+Platform-specific variants also available:<br/>
 `CIBW_ENVIRONMENT_MACOS` | `CIBW_ENVIRONMENT_WINDOWS` | `CIBW_ENVIRONMENT_LINUX`
 
 !!! note
@@ -177,7 +177,9 @@ A shell command to run before building the wheel. This option allows you to run 
 
 If dependencies are required to build your wheel (for example if you include a header from a Python module), set this to `pip install .`, and the dependencies will be installed automatically by pip. However, this means your package will be built twice - if your package takes a long time to build, you might wish to manually list the dependencies here instead.
 
-The active Python binary can be accessed using `python`, and pip with `pip`; `cibuildwheel` makes sure the right version of Python and pip will be executed. `{project}` can be used as a placeholder for the absolute path to the project's root.
+The active Python binary can be accessed using `python`, and pip with `pip`; `cibuildwheel` makes sure the right version of Python and pip will be executed. `{project}` can be used as a placeholder for the absolute path to the project's root and will be replaced by `cibuildwheel`.
+
+On Linux and macOS, the command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
 #### Examples
 ```yaml
@@ -191,12 +193,33 @@ CIBW_BEFORE_BUILD: pip install pybind11
 CIBW_BEFORE_BUILD: yum install -y libffi-dev && pip install .
 ```
 
-Platform-specific variants also available:  
+Platform-specific variants also available:<br/>
  `CIBW_BEFORE_BUILD_MACOS` | `CIBW_BEFORE_BUILD_WINDOWS` | `CIBW_BEFORE_BUILD_LINUX`
 
 
+### `CIBW_REPAIR_COMMAND` {: #repair-command}
+> Execute a shell command to repair each (non-pure Python) built wheel
+
+Default:
+- on Linux: `'auditwheel repair -w {dest_dir} {wheel}'`
+- on macOS: `'delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} {wheel}'`
+- on Windows: `''`
+
+A shell command to repair a built wheel by copying external library dependencies into the wheel tree and relinking them.
+The command is run on each built wheel (except for pure Python ones) before testing it.
+
+The following placeholders must be used inside the command and will be replaced by `cibuildwheel`:
+- `{wheel}` for the absolute path to the built wheel
+- `{dest_dir}` for the absolute path of the directory where to create the repaired wheel.
+
+On Linux and macOS, the command is run in a shell, so you can write things like `cmd1 && cmd2`.
+
+Platform-specific variants also available:<br/>
+`CIBW_REPAIR_COMMAND_MACOS` | `CIBW_REPAIR_COMMAND_WINDOWS` | `CIBW_REPAIR_COMMAND_LINUX`
+
+
 ### `CIBW_MANYLINUX_X86_64_IMAGE`, `CIBW_MANYLINUX_I686_IMAGE` {: #manylinux-image}
-> Specify alternative manylinux docker images 
+> Specify alternative manylinux docker images
 
 An alternative Docker image to be used for building [`manylinux`](https://github.com/pypa/manylinux) wheels. `cibuildwheel` will then pull these instead of the default images, [`quay.io/pypa/manylinux2010_x86_64`](https://quay.io/pypa/manylinux2010_x86_64) and [`quay.io/pypa/manylinux2010_i686`](https://quay.io/pypa/manylinux2010_i686).
 
@@ -221,11 +244,11 @@ CIBW_MANYLINUX_I686_IMAGE: dockcross/manylinux-x86
 ## Testing
 
 ### `CIBW_TEST_COMMAND` {: #test-command}
-> Execute a shell command to test all built wheels
+> Execute a shell command to test each built wheel
 
 Shell command to run tests after the build. The wheel will be installed automatically and available for import from the tests. `{project}` can be used as a placeholder for the absolute path to the project's root and will be replaced by `cibuildwheel`.
 
-On Linux and Mac, the command runs in a shell, so you can write things like `cmd1 && cmd2`. 
+On Linux and macOS, the command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
 #### Examples
 
@@ -237,7 +260,7 @@ CIBW_TEST_COMMAND: nosetests {project}/tests
 CIBW_TEST_COMMAND: nosetests {project}/tests
 ```
 
-Platform-specific variants also available:  
+Platform-specific variants also available:<br/>
 `CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
 
 
@@ -250,13 +273,13 @@ Space-separated list of dependencies required for running the tests.
 
 ```yaml
 # install pytest before running CIBW_TEST_COMMAND
-CIBW_TEST_REQUIRES: pytest  
+CIBW_TEST_REQUIRES: pytest
 
 # install specific versions of test dependencies
 CIBW_TEST_REQUIRES: nose==1.3.7 moto==0.4.31
 ```
 
-Platform-specific variants also available:  
+Platform-specific variants also available:<br/>
 `CIBW_TEST_REQUIRES_MACOS` | `CIBW_TEST_REQUIRES_WINDOWS` | `CIBW_TEST_REQUIRES_LINUX`
 
 ### `CIBW_TEST_EXTRAS` {: #test-extras}
@@ -273,10 +296,10 @@ tests. This can be used to avoid having to redefine test dependencies in
 
 ```yaml
 # will cause the wheel to be installed with `pip install <wheel_file>[test,qt]`
-CIBW_TEST_EXTRAS: test,qt 
+CIBW_TEST_EXTRAS: test,qt
 ```
 
-Platform-specific variants also available:  
+Platform-specific variants also available:<br/>
 `CIBW_TEST_EXTRAS_MACOS` | `CIBW_TEST_EXTRAS_WINDOWS` | `CIBW_TEST_EXTRAS_LINUX`
 
 ## Other
@@ -293,7 +316,7 @@ An number from 1 to 3 to increase the level of verbosity (corresponding to invok
 CIBW_BUILD_VERBOSITY: 1
 ```
 
-Platform-specific variants also available:  
+Platform-specific variants also available:<br/>
 `CIBW_BUILD_VERBOSITY_MACOS` | `CIBW_BUILD_VERBOSITY_WINDOWS` | `CIBW_BUILD_VERBOSITY_LINUX`
 
 ## Command line options
@@ -302,7 +325,7 @@ Platform-specific variants also available:
 usage: cibuildwheel [-h] [--platform {auto,linux,macos,windows}]
                     [--output-dir OUTPUT_DIR] [--print-build-identifiers]
                     [project_dir]
-    
+
 Build wheels for all the platforms.
 
 positional arguments:
@@ -381,7 +404,7 @@ optional arguments:
 
         options[header].push({name: optionName, description, id});
       });
-    
+
     // write the table of contents
 
     var tocTable = $('.options-toc');

--- a/docs/options.md
+++ b/docs/options.md
@@ -197,10 +197,11 @@ Platform-specific variants also available:<br/>
  `CIBW_BEFORE_BUILD_MACOS` | `CIBW_BEFORE_BUILD_WINDOWS` | `CIBW_BEFORE_BUILD_LINUX`
 
 
-### `CIBW_REPAIR_COMMAND` {: #repair-command}
+### `CIBW_REPAIR_WHEEL_COMMAND` {: #repair-wheel-command}
 > Execute a shell command to repair each (non-pure Python) built wheel
 
 Default:
+
 - on Linux: `'auditwheel repair -w {dest_dir} {wheel}'`
 - on macOS: `'delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} {wheel}'`
 - on Windows: `''`
@@ -209,13 +210,24 @@ A shell command to repair a built wheel by copying external library dependencies
 The command is run on each built wheel (except for pure Python ones) before testing it.
 
 The following placeholders must be used inside the command and will be replaced by `cibuildwheel`:
+
 - `{wheel}` for the absolute path to the built wheel
 - `{dest_dir}` for the absolute path of the directory where to create the repaired wheel.
 
 On Linux and macOS, the command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
+#### Examples
+
+```yaml
+# don't repair macOS wheels
+CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
+
+# pass the `--lib-sdir .` flag to auditwheel on Linux
+CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --lib-sdir . -w {dest_dir} {wheel}"
+```
+
 Platform-specific variants also available:<br/>
-`CIBW_REPAIR_COMMAND_MACOS` | `CIBW_REPAIR_COMMAND_WINDOWS` | `CIBW_REPAIR_COMMAND_LINUX`
+`CIBW_REPAIR_WHEEL_COMMAND_MACOS` | `CIBW_REPAIR_WHEEL_COMMAND_WINDOWS` | `CIBW_REPAIR_WHEEL_COMMAND_LINUX`
 
 
 ### `CIBW_MANYLINUX_X86_64_IMAGE`, `CIBW_MANYLINUX_I686_IMAGE` {: #manylinux-image}


### PR DESCRIPTION
to allow different options to auditwheel/delocate, alternative commands and a future Windows-equivalent.

Fix #191 .

Also fix some PEP-008 issues reported by flake8.