### PR TITLE
fix UnboundLocalError instead of proper error message

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -61,25 +61,29 @@ def main():
     args = parser.parse_args()
 
     detect_obsolete_options()
-
     if args.platform != 'auto':
         platform = args.platform
     else:
         ci = strtobool(os.environ.get('CI', 'false')) or 'BITRISE_BUILD_NUMBER' in os.environ or 'AZURE_HTTP_USER_AGENT' in os.environ
-        if ci:
-            if sys.platform.startswith('linux'):
-                platform = 'linux'
-            elif sys.platform == 'darwin':
-                platform = 'macos'
-            elif sys.platform == 'win32':
-                platform = 'windows'
-        if platform is None:
+        if not ci:
             print('cibuildwheel: Unable to detect platform. cibuildwheel should run on your CI server, '
                   'Travis CI, AppVeyor, Azure Pipelines and CircleCI are supported. You can run on your '
                   'development machine or other CI providers using the --platform argument. Check --help '
                   'output for more information.',
                   file=sys.stderr)
             exit(2)
+        if sys.platform.startswith('linux'):
+            platform = 'linux'
+        elif sys.platform == 'darwin':
+            platform = 'macos'
+        elif sys.platform == 'win32':
+            platform = 'windows'
+        else:
+            print('cibuildwheel: Unable to detect platform from "sys.platform" in a CI environment. You can run '
+                  'cibuildwheel using the --platform argument. Check --help output for more information.',
+                  file=sys.stderr)
+            exit(2)
+
 
     output_dir = args.output_dir
     test_command = get_option_from_environment('CIBW_TEST_COMMAND', platform=platform)

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -61,6 +61,7 @@ def main():
     args = parser.parse_args()
 
     detect_obsolete_options()
+    
     if args.platform != 'auto':
         platform = args.platform
     else:
@@ -178,7 +179,7 @@ def main():
     elif platform == 'macos':
         cibuildwheel.macos.build(**build_options)
     else:
-        raise Exception('Unsupported platform')
+        raise Exception('Unsupported platform: {}'.format(platform))
 
 
 def detect_obsolete_options():

--- a/unit_test/platform_test.py
+++ b/unit_test/platform_test.py
@@ -1,0 +1,39 @@
+import sys
+import os
+
+import pytest
+
+from cibuildwheel.__main__ import main
+
+
+def test_unknown_platform_non_ci(monkeypatch, capsys):
+    monkeypatch.setattr(os, 'environ', {})
+    monkeypatch.setattr(sys, "argv", ["python", "."])
+    with pytest.raises(SystemExit) as exit:
+        main()
+    assert exit.value.code == 2
+    _, err = capsys.readouterr()
+    assert 'cibuildwheel: Unable to detect platform.' in err
+    assert "cibuildwheel should run on your CI server" in err
+
+
+def test_unknown_platform_on_ci(monkeypatch, capsys):
+    monkeypatch.setattr(os, 'environ', {"CI": "true"})
+    monkeypatch.setattr(sys, "argv", ["python", "."])
+
+    monkeypatch.setattr(sys, "platform", "Something")
+
+    with pytest.raises(SystemExit) as exit:
+        main()
+    _, err = capsys.readouterr()
+    assert exit.value.code == 2
+    assert 'cibuildwheel: Unable to detect platform from "sys.platform"' in err
+
+
+def test_unknown_platform(monkeypatch):
+    monkeypatch.setattr(os, 'environ', {"CIBW_PLATFORM": "Something"})
+    monkeypatch.setattr(sys, "argv", ["python", "."])
+
+    with pytest.raises(Exception) as exc:
+        main()
+    assert exc.value.args[0] == 'Unsupported platform: Something'


### PR DESCRIPTION
fix for
```
Traceback (most recent call last):
  File "/home/czaki/.pyenv/versions/3.6.8/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/czaki/.pyenv/versions/3.6.8/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/czaki/Projekty/cibuildwheel/cibuildwheel/__main__.py", line 254, in <module>
    main()
  File "/home/czaki/Projekty/cibuildwheel/cibuildwheel/__main__.py", line 76, in main
    if platform is None:
UnboundLocalError: local variable 'platform' referenced before assignment
```