### PR TITLE
Add better protection to unittest to be shure that it will create no changes on developer machine

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -179,7 +179,8 @@ def main():
     elif platform == 'macos':
         cibuildwheel.macos.build(**build_options)
     else:
-        raise Exception('Unsupported platform: {}'.format(platform))
+        print('cibuildwheel: Unsupported platform: {}'.format(platform), file=sys.stderr)
+        exit(2)
 
 
 def detect_obsolete_options():

--- a/unit_test/platform_test.py
+++ b/unit_test/platform_test.py
@@ -1,14 +1,29 @@
 import sys
 import os
+import subprocess
 
 import pytest
 
 from cibuildwheel.__main__ import main
+from cibuildwheel import windows, linux, macos
 
 
-def test_unknown_platform_non_ci(monkeypatch, capsys):
+def not_call_mock(*args, **kwargs):
+    raise RuntimeError("This should never be called")
+
+
+def apply_mock_protection(monkeypatch):
+    monkeypatch.setattr(subprocess, "Popen", not_call_mock)
+    monkeypatch.setattr(windows, "urlopen", not_call_mock)
+    monkeypatch.setattr(windows, "build", not_call_mock)
+    monkeypatch.setattr(linux, "build", not_call_mock)
+    monkeypatch.setattr(macos, "build", not_call_mock)
+
+
+def test_unknown_platform_non_ci(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(os, 'environ', {})
-    monkeypatch.setattr(sys, "argv", ["python", "."])
+    monkeypatch.setattr(sys, "argv", ["python", str(tmp_path)])
+    apply_mock_protection(monkeypatch)
     with pytest.raises(SystemExit) as exit:
         main()
     assert exit.value.code == 2
@@ -17,10 +32,10 @@ def test_unknown_platform_non_ci(monkeypatch, capsys):
     assert "cibuildwheel should run on your CI server" in err
 
 
-def test_unknown_platform_on_ci(monkeypatch, capsys):
+def test_unknown_platform_on_ci(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(os, 'environ', {"CI": "true"})
-    monkeypatch.setattr(sys, "argv", ["python", "."])
-
+    monkeypatch.setattr(sys, "argv", ["python", str(tmp_path)])
+    apply_mock_protection(monkeypatch)
     monkeypatch.setattr(sys, "platform", "Something")
 
     with pytest.raises(SystemExit) as exit:
@@ -30,10 +45,15 @@ def test_unknown_platform_on_ci(monkeypatch, capsys):
     assert 'cibuildwheel: Unable to detect platform from "sys.platform"' in err
 
 
-def test_unknown_platform(monkeypatch):
+def test_unknown_platform(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(os, 'environ', {"CIBW_PLATFORM": "Something"})
-    monkeypatch.setattr(sys, "argv", ["python", "."])
+    monkeypatch.setattr(sys, "argv", ["python", str(tmp_path)])
+    apply_mock_protection(monkeypatch)
+    with open(str(tmp_path / "setup.py"), "w") as f:
+        f.write('from setuptools import setup\nsetup(name="spam", version="0.1.0",)')
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(SystemExit) as exit:
         main()
-    assert exc.value.args[0] == 'Unsupported platform: Something'
+    _, err = capsys.readouterr()
+    assert exit.value.code == 2
+    assert 'cibuildwheel: Unsupported platform: Something' in err


### PR DESCRIPTION
This PR cover really rare case case mentioned in #224. 
This may happen if user do some changes in `main` flow (ex set default platform) then it is possible that build will be launched. 

This PR introduces protection o two levels. Set build directory to temporary, empty dir. and monkeypatch `build`, `subprocess.Popen` and `urlopen`.  

`monkeypatch` will fail if module has no such attribute.
