### PR TITLE
Add possibility to set different enviroment variables for test part

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -102,6 +102,7 @@ def main():
         repair_command_default = ''
     repair_command = get_option_from_environment('CIBW_REPAIR_WHEEL_COMMAND', platform=platform, default=repair_command_default)
     environment_config = get_option_from_environment('CIBW_ENVIRONMENT', platform=platform, default='')
+    test_environment_config = get_option_from_environment('CIBW_ENVIRONMENT_TEST', platform=platform, default='')
 
     if test_extras:
         test_extras = '[{0}]'.format(test_extras)
@@ -119,6 +120,14 @@ def main():
         traceback.print_exc(None, sys.stderr)
         exit(2)
 
+    try:
+        environment_test = parse_environment(test_environment_config)
+    except (EnvironmentParseError, ValueError):
+        print('cibuildwheel: Malformed environment test option "%s"' % environment_config, file=sys.stderr)
+        import traceback
+        traceback.print_exc(None, sys.stderr)
+        exit(2)
+       
     build_selector = BuildSelector(build_config, skip_config)
 
     # Add CIBUILDWHEEL environment variable
@@ -144,6 +153,7 @@ def main():
         build_selector=build_selector,
         repair_command=repair_command,
         environment=environment,
+        environment_test=environment_test
     )
 
     if platform == 'linux':

--- a/cibuildwheel/environment.py
+++ b/cibuildwheel/environment.py
@@ -78,3 +78,10 @@ class ParsedEnvironment(object):
 
     def __repr__(self):
         return 'ParsedEnvironment(%r)' % [repr(a) for a in self.assignments]
+    
+    def __bool__(self):
+        return bool(self.assignments)
+
+    # for python 2
+    def __nonzero__(self):
+        return self.__bool__()

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -30,7 +30,7 @@ def get_python_configurations(build_selector):
     return [c for c in python_configurations if build_selector(c.identifier)]
 
 
-def build(project_dir, output_dir, test_command, test_requires, test_extras, before_build, build_verbosity, build_selector, repair_command, environment, manylinux_images):
+def build(project_dir, output_dir, test_command, test_requires, test_extras, before_build, build_verbosity, build_selector, repair_command, environment, environment_test, manylinux_images):
     try:
         subprocess.check_call(['docker', '--version'])
     except:

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -25,7 +25,7 @@ def get_python_configurations(build_selector):
     return [c for c in python_configurations if build_selector(c.identifier)]
 
 
-def build(project_dir, output_dir, test_command, test_requires, test_extras, before_build, build_verbosity, build_selector, repair_command, environment):
+def build(project_dir, output_dir, test_command, test_requires, test_extras, before_build, build_verbosity, build_selector, repair_command, environment, environment_test):
     abs_project_dir = os.path.abspath(project_dir)
     temp_dir = tempfile.mkdtemp(prefix='cibuildwheel')
     built_wheel_dir = os.path.join(temp_dir, 'built_wheel')
@@ -129,7 +129,10 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             venv_dir = tempfile.mkdtemp()
             call(['python', '-m', 'virtualenv', venv_dir], env=env)
 
-            virtualenv_env = env.copy()
+            if environment_test:
+                virtualenv_env = environment_test.as_dictionary(os.environ.copy())
+            else:
+                virtualenv_env = env.copy()
             virtualenv_env['PATH'] = os.pathsep.join([
                 os.path.join(venv_dir, 'bin'),
                 virtualenv_env['PATH'],

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -58,7 +58,7 @@ def get_python_configurations(build_selector):
     return python_configurations
 
 
-def build(project_dir, output_dir, test_command, test_requires, test_extras, before_build, build_verbosity, build_selector, repair_command, environment):
+def build(project_dir, output_dir, test_command, test_requires, test_extras, before_build, build_verbosity, build_selector, repair_command, environment, environment_test):
     def simple_shell(args, env=None, cwd=None):
         print('+ ' + ' '.join(args))
         args = ['cmd', '/E:ON', '/V:ON', '/C'] + args
@@ -176,7 +176,10 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             venv_dir = tempfile.mkdtemp()
             shell(['python', '-m', 'virtualenv', venv_dir], env=env)
 
-            virtualenv_env = env.copy()
+            if environment_test:
+                virtualenv_env = environment_test.as_dictionary(os.environ.copy())
+            else:
+                virtualenv_env = env.copy()
             virtualenv_env['PATH'] = os.pathsep.join([
                 os.path.join(venv_dir, 'Scripts'),
                 virtualenv_env['PATH'],

--- a/unit_test/environment_test.py
+++ b/unit_test/environment_test.py
@@ -86,3 +86,11 @@ def test_no_vars_pass_through():
     environment_dict = environment_recipe.as_dictionary(prev_environment={'CIBUILDWHEEL': 'awesome'})
 
     assert environment_dict == {'CIBUILDWHEEL': 'awesome'}
+
+def test_bool_conversions():
+    environment_recipe = parse_environment('')
+    assert not environment_recipe
+
+    environment_recipe = parse_environment('A=1')
+    assert environment_recipe
+


### PR DESCRIPTION
In my projects I meet problem that setting environment variable needed for build my package broke building package needed for test. Solution for me is to allow set different set of environment variables for such case.

In this PR I introduce environment variable `CIBW_ENVIRONMENT_TEST` (with platform version).

For MacOS and Windows it is simple. In this moment I do not have idea how to unset environment variable if user use `CIBW_ENVIRONMENT_TEST`. @YannickJadoul @mayeut ? 

- [x] macos
- [x] windows
- [ ] linux
- [x] unit test
- [ ] integration test (?) 
- [ ] documentation