### PR TITLE
Switch examples to use PyPI API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ jobs:
 
 env:
   global:
-    - TWINE_USERNAME=joerick
-      # Note: TWINE_PASSWORD is set in Travis settings
+    - TWINE_USERNAME=__token__
+    # Note: TWINE_PASSWORD is set to a PyPI API token in Travis settings
 
 install:
   - python -m pip install twine cibuildwheel==1.1.0

--- a/examples/travis-ci-deploy-only.yml
+++ b/examples/travis-ci-deploy-only.yml
@@ -19,8 +19,8 @@ jobs:
 
 env:
   global:
-    - TWINE_USERNAME=joerick
-      # Note: TWINE_PASSWORD is set in Travis settings
+    - TWINE_USERNAME=__token__
+    # Note: TWINE_PASSWORD is set to a PyPI API token in Travis settings
 
 install:
   - python -m pip install twine cibuildwheel==1.0.0

--- a/examples/travis-ci-test-and-deploy.yml
+++ b/examples/travis-ci-test-and-deploy.yml
@@ -74,5 +74,5 @@ jobs:
 
 env:
   global:
-    - TWINE_USERNAME=joerick
-      # Note: TWINE_PASSWORD is set in Travis settings
+    - TWINE_USERNAME=__token__
+    # Note: TWINE_PASSWORD is set to a PyPI API token in Travis settings


### PR DESCRIPTION
API tokens came out of beta yesterday, so this PR fixes the examples to use those instead of PyPI passwords

https://pypi.org/help/#apitoken

Fix #154 