### PR TITLE
Add option to specify pip versions on windows

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -164,7 +164,9 @@ def main():
     elif platform == 'macos':
         pass
     elif platform == 'windows':
-        pass
+        pip_version = os.environ.get('CIBW_PIP_VERSION_WINDOWS', None)
+        if pip_version:
+            build_options['pip_version'] = pip_version
 
     # Python is buffering by default when running on the CI platforms, giving problems interleaving subprocess call output with unflushed calls to 'print'
     sys.stdout = Unbuffered(sys.stdout)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -58,7 +58,7 @@ def get_python_configurations(build_selector):
     return python_configurations
 
 
-def build(project_dir, output_dir, test_command, test_requires, test_extras, before_build, build_verbosity, build_selector, repair_command, environment):
+def build(project_dir, output_dir, test_command, test_requires, test_extras, before_build, build_verbosity, build_selector, repair_command, environment, pip_version=None):
     def simple_shell(args, env=None, cwd=None):
         print('+ ' + ' '.join(args))
         args = ['cmd', '/E:ON', '/V:ON', '/C'] + args
@@ -141,7 +141,11 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
         assert os.path.exists(os.path.join(config_python_path, 'Scripts', 'pip.exe'))
 
         # prepare the Python environment
-        simple_shell(['python', '-m', 'pip', 'install', '--upgrade', 'pip'], env=env)
+        if pip_version is not None:
+            pip_str = 'pip==' + pip_version
+        else:
+            pip_str = 'pip'
+        simple_shell(['python', '-m', 'pip', 'install', '--upgrade', pip_str], env=env)
         simple_shell(['pip', '--version'], env=env)
         simple_shell(['pip', 'install', '--upgrade', 'setuptools', 'wheel'], env=env)
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -265,6 +265,19 @@ CIBW_MANYLINUX_X86_64_IMAGE: dockcross/manylinux-x64
 CIBW_MANYLINUX_I686_IMAGE: dockcross/manylinux-x86
 ```
 
+### `CIBW_PIP_VERSION_WINDOWS` {: #windows-pip-version}
+> Specify a specific pip version for windows builds
+
+As par of the windows build process pip is automatically updated to the latest
+version. However, sometimes the latest version of pip isn't desireable to use.
+Using this option you can specify a specific version of pip to use in the
+windows build process.
+
+```yaml
+# Use pip version 19.3.1
+CIBW_PIP_VERSION_WINDOWS=19.3.1
+```
+
 ## Testing
 
 ### `CIBW_TEST_COMMAND` {: #test-command}

--- a/unit_test/main_options_test.py
+++ b/unit_test/main_options_test.py
@@ -28,6 +28,11 @@ def test_output_dir_default(platform, intercepted_build_args, monkeypatch):
 
     assert intercepted_build_args.kwargs['output_dir'] == 'wheelhouse'
 
+def test_pip_version_windows(platform, intercepted_build_args, monkeypatch):
+    monkeypatch.setenv('CIBW_PIP_VERSION_WINDOWS', '19.3.1')
+    main()
+    assert intercepted_build_args
+
 
 @pytest.mark.parametrize('also_set_environment', [False, True])
 def test_output_dir_argument(also_set_environment, platform, intercepted_build_args, monkeypatch):


### PR DESCRIPTION
As part of the initial setup for an environment on windows:
'python -m pip install --upgrade pip' is run unconditionally. However,
there are situtations where a specific version of pip is needed
(normally to avoid issues introduced in new pip releases). This commit
adds a new config env variable flag, CIBW_PIP_VERSION_WINDOWS, which
takes a pip version in that will be used for this command. For example,
if CIBW_PIP_VERSION_WINDOWS=19.3.1 then the windows environment setup
will run 'python -m pip install --upgrade pip=19.3.1'.

Fixes #250