### PR TITLE
Clean up temporary workaround in test/06_docker_images/cibuildwheel_test.py

### DIFF
--- a/test/06_docker_images/cibuildwheel_test.py
+++ b/test/06_docker_images/cibuildwheel_test.py
@@ -9,12 +9,9 @@ def test():
 
     actual_wheels = utils.cibuildwheel_run(project_dir, add_env={
         'CIBW_MANYLINUX_X86_64_IMAGE': 'dockcross/manylinux2010-x64',
-        'CIBW_MANYLINUX_I686_IMAGE': 'dockcross/manylinux1-x86',
-        'CIBW_BEFORE_BUILD': '/opt/python/cp36-cp36m/bin/pip install -U auditwheel',  # Currently necessary on dockcross images to get auditwheel 2.1 supporting AUDITWHEEL_PLAT
-        'CIBW_ENVIRONMENT': 'AUDITWHEEL_PLAT=`if [ $(uname -i) == "x86_64" ]; then echo "manylinux2010_x86_64"; else echo "manylinux1_i686"; fi`',
+        'CIBW_MANYLINUX_I686_IMAGE': 'dockcross/manylinux2010-x86',
     })
 
     # also check that we got the right wheels built
-    expected_wheels = [w for w in utils.expected_wheels('spam', '0.1.0')
-                       if '-manylinux2010_i686' not in w]
+    expected_wheels = utils.expected_wheels('spam', '0.1.0')
     assert set(actual_wheels) == set(expected_wheels)


### PR DESCRIPTION
There is now a `manylinux2010-x86` dockcross image, so we can remove a few hacks :-)