### PR TITLE
Fixing macOS CI and tests after lastest release of virtualenv

### DIFF
--- a/.circleci/prepare.sh
+++ b/.circleci/prepare.sh
@@ -1,6 +1,6 @@
 $PYTHON --version
 $PYTHON -m pip --version
-$PYTHON -m pip install -q --user --ignore-installed --upgrade virtualenv
+$PYTHON -m pip install -q --user --ignore-installed --upgrade "virtualenv<20"
 $PYTHON -m virtualenv -p $PYTHON venv
 venv/bin/python -m pip install -r requirements-dev.txt
 venv/bin/python -m pip freeze

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -130,7 +130,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
         if test_command:
             # set up a virtual environment to install and test from, to make sure
             # there are no dependencies that were pulled in at build time.
-            call(['pip', 'install', 'virtualenv'], env=env)
+            call(['pip', 'install', 'virtualenv<20'], env=env)
             venv_dir = tempfile.mkdtemp()
             call(['python', '-m', 'virtualenv', venv_dir], env=env)
 


### PR DESCRIPTION
Isolating build issues from #185, seemingly related to virtualenv 20.

(Sorry for the PR pollution, but this might be the easiest way to test out a few things.)