### PR TITLE
Revert "Keeping virtualenv<20 on macOS, until problems get fixed by new release"

### DIFF
--- a/.circleci/prepare.sh
+++ b/.circleci/prepare.sh
@@ -1,6 +1,6 @@
 $PYTHON --version
 $PYTHON -m pip --version
-$PYTHON -m pip install -q --user --ignore-installed --upgrade "virtualenv<20"
+$PYTHON -m pip install -q --user --ignore-installed --upgrade virtualenv
 $PYTHON -m virtualenv -p $PYTHON venv
 venv/bin/python -m pip install -r requirements-dev.txt
 venv/bin/python -m pip freeze

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -133,6 +133,9 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             installation_bin_path,
             env['PATH'],
         ])
+        # Fix issue with site.py setting the wrong `sys.prefix`, `sys.exec_prefix`, `sys.path`, ... for PyPy: https://foss.heptapod.net/pypy/pypy/issues/3175
+        # Be safe and avoid other issues by just always removing the '__PYVENV_LAUNCHER__' environment variable (cfr. https://github.com/python/cpython/pull/9516)
+        env.pop('__PYVENV_LAUNCHER__', None)
         env = environment.as_dictionary(prev_environment=env)
 
         # check what version we're on
@@ -203,7 +206,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             ])
             # Fix some weird issue with the shebang of installed scripts
             # See https://github.com/theacodes/nox/issues/44 and https://github.com/pypa/virtualenv/issues/620
-            virtualenv_env.pop('__PYVENV_LAUNCHER__', None)
+            # virtualenv_env.pop('__PYVENV_LAUNCHER__', None)  # No need for this anymore, as '__PYVENV_LAUNCHER__' is already removed from `env` above
 
             # check that we are using the Python from the virtual environment
             call(['which', 'python'], env=virtualenv_env)

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -133,8 +133,13 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             installation_bin_path,
             env['PATH'],
         ])
-        # Fix issue with site.py setting the wrong `sys.prefix`, `sys.exec_prefix`, `sys.path`, ... for PyPy: https://foss.heptapod.net/pypy/pypy/issues/3175
-        # Be safe and avoid other issues by just always removing the '__PYVENV_LAUNCHER__' environment variable (cfr. https://github.com/python/cpython/pull/9516)
+
+        # Fix issue with site.py setting the wrong `sys.prefix`, `sys.exec_prefix`,
+        # `sys.path`, ... for PyPy: https://foss.heptapod.net/pypy/pypy/issues/3175
+        # Also fix an issue with the shebang of installed scripts inside the 
+        # testing virtualenv- see https://github.com/theacodes/nox/issues/44 and
+        # https://github.com/pypa/virtualenv/issues/620 
+        # Also see https://github.com/python/cpython/pull/9516
         env.pop('__PYVENV_LAUNCHER__', None)
         env = environment.as_dictionary(prev_environment=env)
 
@@ -204,9 +209,6 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                 os.path.join(venv_dir, 'bin'),
                 virtualenv_env['PATH'],
             ])
-            # Fix some weird issue with the shebang of installed scripts
-            # See https://github.com/theacodes/nox/issues/44 and https://github.com/pypa/virtualenv/issues/620
-            # virtualenv_env.pop('__PYVENV_LAUNCHER__', None)  # No need for this anymore, as '__PYVENV_LAUNCHER__' is already removed from `env` above
 
             # check that we are using the Python from the virtual environment
             call(['which', 'python'], env=virtualenv_env)

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -192,7 +192,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
         if test_command:
             # set up a virtual environment to install and test from, to make sure
             # there are no dependencies that were pulled in at build time.
-            call(['pip', 'install', 'virtualenv<20'], env=env)
+            call(['pip', 'install', 'virtualenv'], env=env)
             venv_dir = tempfile.mkdtemp()
             call(['python', '-m', 'virtualenv', venv_dir], env=env)
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -136,9 +136,9 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
         # Fix issue with site.py setting the wrong `sys.prefix`, `sys.exec_prefix`,
         # `sys.path`, ... for PyPy: https://foss.heptapod.net/pypy/pypy/issues/3175
-        # Also fix an issue with the shebang of installed scripts inside the 
+        # Also fix an issue with the shebang of installed scripts inside the
         # testing virtualenv- see https://github.com/theacodes/nox/issues/44 and
-        # https://github.com/pypa/virtualenv/issues/620 
+        # https://github.com/pypa/virtualenv/issues/620
         # Also see https://github.com/python/cpython/pull/9516
         env.pop('__PYVENV_LAUNCHER__', None)
         env = environment.as_dictionary(prev_environment=env)


### PR DESCRIPTION
The issue (pypa/virtualenv#1561) was fixed by PR pypa/virtualenv#1641, and is now released in virtualenv 20.0.5. Let's undo the hack/workaround.