### PR TITLE
Change twine references to be immediately preceded by pip install in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ env:
     # Note: TWINE_PASSWORD is set to a PyPI API token in Travis settings
 
 install:
-  - python3 -m pip install twine cibuildwheel==1.1.0
+  - python3 -m pip install cibuildwheel==1.1.0
 
 script:
   # build the wheels, put them into './wheelhouse'
@@ -83,7 +83,11 @@ script:
 
 after_success:
   # if the release was tagged, upload them to PyPI
-  - if [[ $TRAVIS_TAG ]]; then python3 -m twine upload wheelhouse/*.whl; fi
+  - |
+    if [[ $TRAVIS_TAG ]]; then
+      python3 -m pip install twine
+      python3 -m twine upload wheelhouse/*.whl
+    fi
 ```
 
 For more information, including how to build on Appveyor, Azure, CircleCI, check out the [documentation](https://cibuildwheel.readthedocs.org) and also check out [the examples](https://github.com/joerick/cibuildwheel/tree/master/examples).

--- a/examples/travis-ci-deploy-only.yml
+++ b/examples/travis-ci-deploy-only.yml
@@ -23,7 +23,7 @@ env:
     # Note: TWINE_PASSWORD is set to a PyPI API token in Travis settings
 
 install:
-  - python3 -m pip install twine cibuildwheel==1.1.0
+  - python3 -m pip install cibuildwheel==1.1.0
 
 script:
   # build the wheels, put them into './wheelhouse'
@@ -31,4 +31,8 @@ script:
 
 after_success:
   # if the release was tagged, upload them to PyPI
-  - if [[ $TRAVIS_TAG ]]; then python3 -m twine upload wheelhouse/*.whl; fi
+  - |
+    if [[ $TRAVIS_TAG ]]; then
+      python3 -m pip install twine
+      python3 -m twine upload wheelhouse/*.whl
+    fi

--- a/examples/travis-ci-test-and-deploy.yml
+++ b/examples/travis-ci-test-and-deploy.yml
@@ -47,30 +47,38 @@ jobs:
       name: Deploy source distribution
       install: skip
       script: python3 setup.py sdist --formats=gztar
-      after_success: python3 -m twine upload --skip-existing dist/*.tar.gz
+      after_success: |
+        python3 -m pip install twine
+        python3 -m twine upload --skip-existing dist/*.tar.gz
     # Deploy on linux
     - stage: deploy
       name: Build and deploy Linux wheels
       services: docker
-      install: python3 -m pip install twine cibuildwheel==1.1.0
+      install: python3 -m pip install cibuildwheel==1.1.0
       script: python3 -m cibuildwheel --output-dir wheelhouse
-      after_success: python3 -m twine upload --skip-existing wheelhouse/*.whl
+      after_success: |
+        python3 -m pip install twine
+        python3 -m twine upload --skip-existing wheelhouse/*.whl
     # Deploy on mac
     - stage: deploy
       name: Build and deploy macOS wheels
       os: osx
       language: shell
-      install: python3 -m pip install twine cibuildwheel==1.1.0
+      install: python3 -m pip install cibuildwheel==1.1.0
       script: python3 -m cibuildwheel --output-dir wheelhouse
-      after_success: python3 -m twine upload --skip-existing wheelhouse/*.whl
+      after_success: |
+        python3 -m pip install twine
+        python3 -m twine upload --skip-existing wheelhouse/*.whl
     # Deploy on windows
     - stage: deploy
       name: Build and deploy Windows wheels
       os: windows
       language: shell
-      install: python3 -m pip install twine cibuildwheel==1.1.0
+      install: python3 -m pip install cibuildwheel==1.1.0
       script: python3 -m cibuildwheel --output-dir wheelhouse
-      after_success: python3 -m twine upload --skip-existing wheelhouse/*.whl
+      after_success: |
+        python3 -m pip install twine
+        python3 -m twine upload --skip-existing wheelhouse/*.whl
 
 env:
   global:


### PR DESCRIPTION
This ensures that the python that installs is the same python that
should execute the module (this sometimes isn't true on macOS because
the python.org installs that cibuildwheel makes take precedence over
the system versions)

Fix #266