### PR TITLE
change 02_test to check if virtualenv is properly used

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -145,6 +145,8 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                     venv_dir=`mktemp -d`/venv
                     python -m virtualenv "$venv_dir"
 
+                    export __CIBW_VIRTUALENV_PATH__=$venv_dir
+
                     # run the tests in a subshell to keep that `activate`
                     # script from polluting the env
                     (

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -209,6 +209,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                 os.path.join(venv_dir, 'bin'),
                 virtualenv_env['PATH'],
             ])
+            virtualenv_env["__CIBW_VIRTUALENV_PATH__"] = venv_dir
 
             # check that we are using the Python from the virtual environment
             call(['which', 'python'], env=virtualenv_env)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -197,6 +197,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                 os.path.join(venv_dir, 'Scripts'),
                 virtualenv_env['PATH'],
             ])
+            virtualenv_env["__CIBW_VIRTUALENV_PATH__"] = venv_dir
 
             # check that we are using the Python from the virtual environment
             shell(['which', 'python'], env=virtualenv_env)

--- a/test/02_test/test/spam_test.py
+++ b/test/02_test/test/spam_test.py
@@ -18,9 +18,11 @@ class TestSpam(TestCase):
 
     def test_virtualenv(self):
         virtualenv_path = normalize_path(os.environ.get("__CIBW_VIRTUALENV_PATH__"))
+        if not virtualenv_path:
+            self.fail("No virtualenv path defined in environment variable __CIBW_VIRTUALENV_PATH__")
+
         print("=[executable]", sys.executable)
         print("=[spam location]", spam.__file__)
         print("=[virtualenv path]", virtualenv_path)
         self.assertTrue(virtualenv_path in normalize_path(sys.executable))
         self.assertTrue(virtualenv_path in normalize_path(spam.__file__))
-

--- a/test/02_test/test/spam_test.py
+++ b/test/02_test/test/spam_test.py
@@ -1,9 +1,26 @@
+from __future__ import print_function
+import os
+import sys
 from unittest import TestCase
 
 import spam
+
+
+def normalize_path(path_str):
+    """because of windows short path"""
+    return os.path.normcase(path_str).replace("vssadm~1", "vssadministrator")
 
 
 class TestSpam(TestCase):
     def test_system(self):
         self.assertEqual(0, spam.system('python -c "exit(0)"'))
         self.assertNotEqual(0, spam.system('python -c "exit(1)"'))
+
+    def test_virtualenv(self):
+        virtualenv_path = normalize_path(os.environ.get("__CIBW_VIRTUALENV_PATH__"))
+        print("=[executable]", sys.executable)
+        print("=[spam location]", spam.__file__)
+        print("=[virtualenv path]", virtualenv_path)
+        self.assertTrue(virtualenv_path in normalize_path(sys.executable))
+        self.assertTrue(virtualenv_path in normalize_path(spam.__file__))
+

--- a/test/02_test/test/spam_test.py
+++ b/test/02_test/test/spam_test.py
@@ -24,5 +24,10 @@ class TestSpam(TestCase):
         print("=[executable]", sys.executable)
         print("=[spam location]", spam.__file__)
         print("=[virtualenv path]", virtualenv_path)
+        print("=[listdir]", os.listdir(virtualenv_path))
+        if os.path.exists(os.path.join(virtualenv_path, 'Scripts')):
+            print("=[listdir]2", os.listdir(os.path.join(virtualenv_path, 'Scripts')))
+        if os.path.exists(os.path.join(virtualenv_path, 'bin')):
+            print("=[listdir]2", os.listdir(os.path.join(virtualenv_path, 'bin')))
         self.assertTrue(virtualenv_path in normalize_path(sys.executable))
         self.assertTrue(virtualenv_path in normalize_path(spam.__file__))


### PR DESCRIPTION
During rebase of #242 I found that creating virtualenv for pypy on windows is buggy. This PR contains test which check if proper virtualenv is used. On travis error is good visible:

```
AIL: test_virtualenv (spam_test.TestSpam)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\travis\build\Czaki\cibuildwheel\test\02_test\test\spam_test.py", line 18, in test_virtualenv
    self.assertTrue(virtualenv_path in sys.executable.lower())
AssertionError: False is not true

-------------------- >> begin captured stdout << ---------------------
=[executable] c:\cibw\pypy3.6-v7.3.0-win32\python.exe
=[spam location] c:\cibw\pypy3.6-v7.3.0-win32\site-packages\spam.pypy36-pp73-win32.pyd
=[virtualenv path] c:\users\travis\appdata\local\temp\tmpinjk7b6y
--------------------- >> end captured stdout << ----------------------
```

@YannickJadoul Here is minimal example of problem with virtualenv. I think that this test should be merged.

In contrast to previous one this problem occurs only in pypy so I call also @mattip