### PR TITLE
Separate python install process to avoid timeout problem

### DIFF
--- a/test/01_basic/cibuildwheel_test.py
+++ b/test/01_basic/cibuildwheel_test.py
@@ -1,9 +1,23 @@
 import os
 import platform
 
+import pytest
+
 import utils
 
 project_dir = os.path.dirname(__file__)
+
+
+@pytest.mark.parametrize("build_prefix", ["cp27", "cp35", "cp36", "cp37", "cp38", "pp27", "pp36"])
+def test_single(build_prefix):
+    """To force installation all python for test"""
+    project_dir = os.path.dirname(__file__)
+    # build the wheels
+    actual_wheels = utils.cibuildwheel_run(project_dir, add_env={
+        'CIBW_BUILD': build_prefix + "*",
+    })
+    expected_wheels = [x for x in utils.expected_wheels('spam', '0.1.0') if build_prefix in x]
+    assert set(actual_wheels) == set(expected_wheels)
 
 
 def test():


### PR DESCRIPTION
Installing multiple python version takes long time. Pytest hide stdout produced during test run. 
So maybe it is a good idea to separate python installation tasks to get information to stdout. Hence I create `test_single` in first groups of test which run cibuildwheel on each python version separately. 

Python is installed once per test session 