### PR TITLE
Setup python extracted from build function

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ build: off
 init:
 - cmd: set PATH=C:\Python37;C:\Python37\Scripts;%PATH%
 
-install: python -m pip install -r requirements-dev.txt
+install: python -m pip install --retries 3 -r requirements-dev.txt
 
 # the '-u' flag is required so the output is in the correct order.
 # See https://github.com/joerick/cibuildwheel/pull/24 for more info.

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -108,6 +108,69 @@ def install_pypy(version, url):
     return installation_bin_path
 
 
+def setup_python(python_configuration, dependency_constraints, environment):
+    if python_configuration.identifier.startswith('cp'):
+        installation_bin_path = install_cpython(python_configuration.version, python_configuration.url)
+    elif python_configuration.identifier.startswith('pp'):
+        installation_bin_path = install_pypy(python_configuration.version, python_configuration.url)
+    else:
+        raise ValueError("Unknown Python implementation")
+    
+    env = os.environ.copy()
+    env['PATH'] = os.pathsep.join([
+        SYMLINKS_DIR,
+        installation_bin_path,
+        env['PATH'],
+    ])
+
+    # Fix issue with site.py setting the wrong `sys.prefix`, `sys.exec_prefix`,
+    # `sys.path`, ... for PyPy: https://foss.heptapod.net/pypy/pypy/issues/3175
+    # Also fix an issue with the shebang of installed scripts inside the
+    # testing virtualenv- see https://github.com/theacodes/nox/issues/44 and
+    # https://github.com/pypa/virtualenv/issues/620
+    # Also see https://github.com/python/cpython/pull/9516
+    env.pop('__PYVENV_LAUNCHER__', None)
+    env = environment.as_dictionary(prev_environment=env)
+
+    # check what version we're on
+    call(['which', 'python'], env=env)
+    call(['python', '--version'], env=env)
+    which_python = subprocess.check_output(['which', 'python'], env=env, universal_newlines=True).strip()
+    if which_python != '/tmp/cibw_bin/python':
+        print("cibuildwheel: python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it.", file=sys.stderr)
+        exit(1)
+
+    dependency_constraint_flags = []
+    if dependency_constraints:
+        dependency_constraint_flags = [
+            '-c', dependency_constraints.get_for_python_version(python_configuration.version)
+        ]
+
+    # install pip & wheel
+    call(['python', get_pip_script] + dependency_constraint_flags, env=env, cwd="/tmp")
+    assert os.path.exists(os.path.join(installation_bin_path, 'pip'))
+    call(['which', 'pip'], env=env)
+    call(['pip', '--version'], env=env)
+    which_pip = subprocess.check_output(['which', 'pip'], env=env, universal_newlines=True).strip()
+    if which_pip != '/tmp/cibw_bin/pip':
+        print("cibuildwheel: pip available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert pip above it.", file=sys.stderr)
+        exit(1)
+    call(['pip', 'install', '--upgrade', 'setuptools', 'wheel', 'delocate'] + dependency_constraint_flags, env=env)
+
+    # setup target platform, only required for python 3.5
+    if python_configuration.version == '3.5':
+        if '_PYTHON_HOST_PLATFORM' not in env:
+            # cross-compilation platform override
+            env['_PYTHON_HOST_PLATFORM'] = 'macosx-10.9-x86_64'
+        if 'ARCHFLAGS' not in env:
+            # https://github.com/python/cpython/blob/a5ed2fe0eedefa1649aa93ee74a0bafc8e628a10/Lib/_osx_support.py#L260
+            env['ARCHFLAGS'] = '-arch x86_64'
+        if 'MACOSX_DEPLOYMENT_TARGET' not in env:
+            env['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
+
+    return env, dependency_constraint_flags
+
+
 def build(project_dir, output_dir, test_command, before_test, test_requires, test_extras, before_build, build_verbosity, build_selector, repair_command, environment, dependency_constraints):
     abs_project_dir = os.path.abspath(project_dir)
     temp_dir = tempfile.mkdtemp(prefix='cibuildwheel')
@@ -117,64 +180,8 @@ def build(project_dir, output_dir, test_command, before_test, test_requires, tes
     python_configurations = get_python_configurations(build_selector)
 
     for config in python_configurations:
-        if config.identifier.startswith('cp'):
-            installation_bin_path = install_cpython(config.version, config.url)
-        elif config.identifier.startswith('pp'):
-            installation_bin_path = install_pypy(config.version, config.url)
-        else:
-            raise ValueError("Unknown Python implementation")
+        env, dependency_constraint_flags = setup_python(config, dependency_constraints, environment)
 
-        env = os.environ.copy()
-        env['PATH'] = os.pathsep.join([
-            SYMLINKS_DIR,
-            installation_bin_path,
-            env['PATH'],
-        ])
-
-        # Fix issue with site.py setting the wrong `sys.prefix`, `sys.exec_prefix`,
-        # `sys.path`, ... for PyPy: https://foss.heptapod.net/pypy/pypy/issues/3175
-        # Also fix an issue with the shebang of installed scripts inside the
-        # testing virtualenv- see https://github.com/theacodes/nox/issues/44 and
-        # https://github.com/pypa/virtualenv/issues/620
-        # Also see https://github.com/python/cpython/pull/9516
-        env.pop('__PYVENV_LAUNCHER__', None)
-        env = environment.as_dictionary(prev_environment=env)
-
-        # check what version we're on
-        call(['which', 'python'], env=env)
-        call(['python', '--version'], env=env)
-        which_python = subprocess.check_output(['which', 'python'], env=env, universal_newlines=True).strip()
-        if which_python != '/tmp/cibw_bin/python':
-            print("cibuildwheel: python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it.", file=sys.stderr)
-            exit(1)
-
-        dependency_constraint_flags = []
-        if dependency_constraints:
-            dependency_constraint_flags = [
-                '-c', dependency_constraints.get_for_python_version(config.version)
-            ]
-
-        # install pip & wheel
-        call(['python', get_pip_script] + dependency_constraint_flags, env=env, cwd="/tmp")
-        assert os.path.exists(os.path.join(installation_bin_path, 'pip'))
-        call(['which', 'pip'], env=env)
-        call(['pip', '--version'], env=env)
-        which_pip = subprocess.check_output(['which', 'pip'], env=env, universal_newlines=True).strip()
-        if which_pip != '/tmp/cibw_bin/pip':
-            print("cibuildwheel: pip available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert pip above it.", file=sys.stderr)
-            exit(1)
-        call(['pip', 'install', '--upgrade', 'setuptools', 'wheel', 'delocate'] + dependency_constraint_flags, env=env)
-
-        # setup target platform, only required for python 3.5
-        if config.version == '3.5':
-            if '_PYTHON_HOST_PLATFORM' not in env:
-                # cross-compilation platform override
-                env['_PYTHON_HOST_PLATFORM'] = 'macosx-10.9-x86_64'
-            if 'ARCHFLAGS' not in env:
-                # https://github.com/python/cpython/blob/a5ed2fe0eedefa1649aa93ee74a0bafc8e628a10/Lib/_osx_support.py#L260
-                env['ARCHFLAGS'] = '-arch x86_64'
-            if 'MACOSX_DEPLOYMENT_TARGET' not in env:
-                env['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
 
         # run the before_build command
         if before_build:


### PR DESCRIPTION
For windows and macos extract python setup to separate function and rename `windows.shell` to `windows.call` to unify `build` function between systems.

Main advantage of this PR is separate build wheel logic from python setup logic. Build function is shorter and easier to analyse. 

This also allow to simplify user porting on CI which are not possible to test from github like gitlab (#158)