### PR TITLE
Build PR branches only once (for origin branches) and skip docs changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,8 @@ name: Test
 
 on:
   push:
-    - master
+    branches:
+      - master
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,16 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - master
+  push: {}
   pull_request:
     paths-ignore:
       - 'docs/**'
 
 jobs:
   test:
+    # skip branch builds on joerick/cibuildwheel, but always build `master` and pull requests
+    if: github.repository != 'joerick/cibuildwheel' || github.ref == 'refs/heads/master' || github.event_name == 'pull_request'
+
     name: Test cibuildwheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    - master
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   test:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: minimal
 
+branches:
+  only:
+  - master
+
 jobs:
   include:
     - name: Linux | x86_64 + i686 | Python 3.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,3 +19,11 @@ install: python -m pip install -r requirements-dev.txt
 # the '-u' flag is required so the output is in the correct order.
 # See https://github.com/joerick/cibuildwheel/pull/24 for more info.
 test_script: python -u ./bin/run_tests.py
+
+branches:
+  only:
+    - master
+
+skip_commits:
+  files:
+    - docs/*


### PR DESCRIPTION
My PR branches get built twice on some CI services (Appveyor, Travis, Github), once for the PR and once for the branch. This disables the branch build, for anything other than master, to save some CI time.

Also, on services that support it, I've disabled docs changes from needing CI runs.