### PR TITLE
Add type annotations and drop Python 3.5 host support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,22 +30,6 @@ jobs:
           command: venv/bin/python ./bin/run_tests.py
           no_output_timeout: 30m
 
-  osx-python3.7:
-    macos:
-      xcode: "10.0.0"
-    environment:
-      PYTHON: python3
-    steps:
-      - checkout
-
-      - run:
-          name: Prepare the environment.
-          command: bash .circleci/prepare.sh
-      - run:
-          name: Test.
-          command: venv/bin/python ./bin/run_tests.py
-          no_output_timeout: 30m
-
   linux-python3.6:
     docker:
       - image: circleci/python:3.6
@@ -69,5 +53,4 @@ workflows:
     jobs:
       - flake8
       - osx-python3.6
-      - osx-python3.7
       - linux-python3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,21 @@
 version: 2
 
 jobs:
-  flake8:
+  flake8-mypy:
     docker:
       - image: circleci/python:3.6
     steps:
       - checkout
 
       - run:
-          name: Install flake8
-          command: sudo python -m pip install flake8
+          name: Install flake8 & mypy
+          command: sudo python -m pip install flake8 mypy
       - run:
-          name: Test.
-          command: flake8 .
+          name: flake8
+          command: flake8
+      - run:
+          name: mypy
+          command: mypy
 
   osx-python3.6:
     macos:
@@ -51,6 +54,6 @@ workflows:
   version: 2
   all-tests:
     jobs:
-      - flake8
+      - flake8-mypy
       - osx-python3.6
       - linux-python3.6

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ env3?/
 
 # VSCode project settings
 /.vscode
+
+# MyPy cache
+.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,22 @@ branches:
 
 jobs:
   include:
-    - name: Linux | x86_64 + i686 | Python 3.5
+    - name: Linux | x86_64 + i686 | Python 3.6
       language: python
-      python: 3.5
+      python: 3.6
       services: docker
       env: PYTHON=python
 
-    - name: Linux | arm64 | Python 3.5
+    - name: Linux | arm64 | Python 3.6
       language: python
-      python: 3.5
+      python: 3.6
       services: docker
       arch: arm64
       env: PYTHON=python
 
-    - name: Linux | ppc64le | Python 3.5
+    - name: Linux | ppc64le | Python 3.6
       language: python
-      python: 3.5
+      python: 3.6
       services: docker
       arch: ppc64le
       env: PYTHON=python
@@ -30,25 +30,25 @@ jobs:
       os: osx
       env: PYTHON=python3
 
-    - name: Windows | x86_64 | Python 3.5
+    - name: Windows | x86_64 | Python 3.6
       os: windows
       language: shell
       before_install:
-       - choco install python3 --version 3.5.4 --no-progress -y
+       - choco install python3 --version 3.6.8 --no-progress -y
       env:
-        - PYTHON=C:\\Python35\\python
+        - PYTHON=C:\\Python36\\python
 
-    - &linux_s390x_35
-      name: Linux | s390x | Python 3.5
+    - &linux_s390x_36
+      name: Linux | s390x | Python 365
       language: python
-      python: 3.5
+      python: 3.6
       services: docker
       arch: s390x
       env: PYTHON=python
 
   allow_failures:
     # must repeat the s390x job above exactly to match
-    - *linux_s390x_35
+    - *linux_s390x_36
 
 install: $PYTHON -m pip install -r requirements-dev.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         - PYTHON=C:\\Python36\\python
 
     - &linux_s390x_36
-      name: Linux | s390x | Python 365
+      name: Linux | s390x | Python 3.6
       language: python
       python: 3.6
       services: docker

--- a/CI.md
+++ b/CI.md
@@ -1,12 +1,12 @@
 This is a summary of the Python versions and platforms covered by the different CI platforms:
 
-|          | 3.5              | 3.6              | 3.7                                                | 3.8              |
-|----------|------------------|------------------|----------------------------------------------------|------------------|
-| Linux    | Travis CI        | CircleCI         | AppVeyor² / GitHub Actions                         | Azure Pipelines  |
-| macOS    | Azure Pipelines  | CircleCI         | AppVeyor² / Travis CI¹ / CircleCI / GitHub Actions | Azure Pipelines  |
-| Windows  | TravisCI         | Azure Pipelines  | AppVeyor² / GitHub Actions                         | Azure Pipelines  |
+|          | 3.6                          | 3.7                                                 | 3.8              |
+|----------|------------------------------|-----------------------------------------------------|------------------|
+| Linux    | Travis CI / CircleCI         | AppVeyor² / GitHub Actions                          | Azure Pipelines  |
+| macOS    | CircleCI                     | AppVeyor² / Travis CI¹ / CircleCI / GitHub Actions  | Azure Pipelines  |
+| Windows  | Travis CI / Azure Pipelines  | AppVeyor² / GitHub Actions                          | Azure Pipelines  |
 
 > ¹ Python version not really pinned, but dependent on the (default) version of image used.
 > ² AppVeyor only runs the "basic" test to reduce load.
 
-Non-x86 architectures are covered on Travis CI using Python 3.5.
+Non-x86 architectures are covered on Travis CI using Python 3.6.

--- a/CI.md
+++ b/CI.md
@@ -1,10 +1,10 @@
 This is a summary of the Python versions and platforms covered by the different CI platforms:
 
-|          | 3.6                          | 3.7                                                 | 3.8              |
-|----------|------------------------------|-----------------------------------------------------|------------------|
-| Linux    | Travis CI / CircleCI         | AppVeyor² / GitHub Actions                          | Azure Pipelines  |
-| macOS    | CircleCI                     | AppVeyor² / Travis CI¹ / CircleCI / GitHub Actions  | Azure Pipelines  |
-| Windows  | Travis CI / Azure Pipelines  | AppVeyor² / GitHub Actions                          | Azure Pipelines  |
+|          | 3.6                          | 3.7                                      | 3.8              |
+|----------|------------------------------|------------------------------------------|------------------|
+| Linux    | Travis CI / CircleCI         | AppVeyor² / GitHub Actions               | Azure Pipelines  |
+| macOS    | CircleCI                     | AppVeyor² / Travis CI¹ / GitHub Actions  | Azure Pipelines  |
+| Windows  | Travis CI / Azure Pipelines  | AppVeyor² / GitHub Actions               | Azure Pipelines  |
 
 > ¹ Python version not really pinned, but dependent on the (default) version of image used.
 > ² AppVeyor only runs the "basic" test to reduce load.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,16 +9,6 @@ jobs:
         python -m pip install -r requirements-dev.txt
         python ./bin/run_tests.py
 
-- job: macos_35
-  pool: {vmImage: 'macOS-10.15'}
-  steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.5'
-    - bash: |
-        python -m pip install -r requirements-dev.txt
-        python ./bin/run_tests.py
-
 - job: macos_38
   pool: {vmImage: 'macOS-10.15'}
   steps:

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -134,7 +134,7 @@ def main() -> None:
 
     dependency_versions = get_option_from_environment('CIBW_DEPENDENCY_VERSIONS', platform=platform, default='pinned')
     if dependency_versions == 'pinned':
-        dependency_constraints = DependencyConstraints.with_defaults()
+        dependency_constraints = DependencyConstraints.with_defaults()  # type: Optional[DependencyConstraints]
     elif dependency_versions == 'latest':
         dependency_constraints = None
     else:
@@ -169,6 +169,7 @@ def main() -> None:
         print_build_identifiers(platform, build_selector)
         exit(0)
 
+    manylinux_images = None  # type: Optional[Dict[str, str]]
     if platform == 'linux':
         pinned_docker_images_file = os.path.join(
             os.path.dirname(__file__), 'resources', 'pinned_docker_images.cfg'
@@ -181,8 +182,7 @@ def main() -> None:
         #   'pypy_x86_64': {'manylinux2010': '...' }
         #   ... }
 
-        manylinux_images = {}  # type: Optional[Dict[str, str]]
-        assert manylinux_images is not None  # Weird problem with mypy
+        manylinux_images = {}
 
         for build_platform in ['x86_64', 'i686', 'pypy_x86_64', 'aarch64', 'ppc64le', 's390x']:
             pinned_images = all_pinned_docker_images[build_platform]
@@ -199,9 +199,6 @@ def main() -> None:
                 image = config_value
 
             manylinux_images[build_platform] = image
-
-    else:
-        manylinux_images = None
 
     build_options = BuildOptions(
         package_dir=package_dir,

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -5,7 +5,7 @@ import textwrap
 import traceback
 from configparser import ConfigParser
 
-from typing import Any, Dict, List, Optional, Union, overload
+from typing import Any, Dict, List, Optional, overload
 
 import cibuildwheel
 import cibuildwheel.linux
@@ -24,12 +24,10 @@ from cibuildwheel.util import (
 
 
 @overload
-def get_option_from_environment(option_name: str, platform: Optional[str], default: str) -> str:
-    ...
+def get_option_from_environment(option_name: str, platform: Optional[str], default: str) -> str: ...  # noqa: E704
 @overload
-def get_option_from_environment(option_name: str, platform: Optional[str] = None, default: None = None) -> Optional[str]:
-    ...
-def get_option_from_environment(option_name: str, platform: Optional[str] = None, default: Optional[str] = None) -> Optional[str]:
+def get_option_from_environment(option_name: str, platform: Optional[str] = None, default: None = None) -> Optional[str]: ...  # noqa: E704 E302
+def get_option_from_environment(option_name: str, platform: Optional[str] = None, default: Optional[str] = None) -> Optional[str]:  # noqa: E302
     '''
     Returns an option from the environment, optionally scoped by the platform.
 

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -134,7 +134,7 @@ def main() -> None:
 
     dependency_versions = get_option_from_environment('CIBW_DEPENDENCY_VERSIONS', platform=platform, default='pinned')
     if dependency_versions == 'pinned':
-        dependency_constraints = DependencyConstraints.with_defaults()  # type: Optional[DependencyConstraints]
+        dependency_constraints: Optional[DependencyConstraints] = DependencyConstraints.with_defaults()
     elif dependency_versions == 'latest':
         dependency_constraints = None
     else:
@@ -169,7 +169,7 @@ def main() -> None:
         print_build_identifiers(platform, build_selector)
         exit(0)
 
-    manylinux_images = None  # type: Optional[Dict[str, str]]
+    manylinux_images: Optional[Dict[str, str]] = None
     if platform == 'linux':
         pinned_docker_images_file = os.path.join(
             os.path.dirname(__file__), 'resources', 'pinned_docker_images.cfg'
@@ -287,14 +287,13 @@ def print_preamble(platform: str, build_options: BuildOptions) -> None:
 
 
 def print_build_identifiers(platform: str, build_selector: BuildSelector) -> None:
+    python_configurations: List[Any] = []
     if platform == 'linux':
-        python_configurations = cibuildwheel.linux.get_python_configurations(build_selector)  # type: List[Any]
+        python_configurations = cibuildwheel.linux.get_python_configurations(build_selector)
     elif platform == 'windows':
         python_configurations = cibuildwheel.windows.get_python_configurations(build_selector)
     elif platform == 'macos':
         python_configurations = cibuildwheel.macos.get_python_configurations(build_selector)
-    else:
-        python_configurations = []
 
     for config in python_configurations:
         print(config.identifier)

--- a/cibuildwheel/bashlex_eval.py
+++ b/cibuildwheel/bashlex_eval.py
@@ -1,6 +1,5 @@
 import shlex
 import subprocess
-from collections import namedtuple
 
 from typing import Dict, List, NamedTuple, Optional
 

--- a/cibuildwheel/bashlex_eval.py
+++ b/cibuildwheel/bashlex_eval.py
@@ -5,9 +5,10 @@ from typing import Dict, List, NamedTuple, Optional
 
 import bashlex  # type: ignore
 
-NodeExecutionContext = NamedTuple('NodeExecutionContext',
-                                  [('environment', Dict[str, str]),
-                                   ('input', str)])
+
+class NodeExecutionContext(NamedTuple):
+    environment: Dict[str, str]
+    input: str
 
 
 def evaluate(value: str, environment: Dict[str, str]) -> str:
@@ -44,7 +45,7 @@ def evaluate_word_node(node: bashlex.ast.node, context: NodeExecutionContext) ->
     word_start = node.pos[0]
     word_end = node.pos[1]
     word_string = context.input[word_start:word_end]
-    letters = list(word_string)  # type: List[Optional[str]]
+    letters: List[Optional[str]] = list(word_string)
 
     for part in node.parts:
         part_start = part.pos[0] - word_start

--- a/cibuildwheel/bashlex_eval.py
+++ b/cibuildwheel/bashlex_eval.py
@@ -2,12 +2,14 @@ import shlex
 import subprocess
 from collections import namedtuple
 
-import bashlex
+from typing import Dict
+
+import bashlex  # type: ignore
 
 NodeExecutionContext = namedtuple('NodeExecutionContext', ['environment', 'input'])
 
 
-def evaluate(value, environment):
+def evaluate(value: str, environment: Dict[str, str]) -> str:
     if not value:
         # empty string evaluates to empty string
         # (but trips up bashlex)
@@ -20,24 +22,24 @@ def evaluate(value, environment):
 
     value_word_node = command_node.parts[0]
 
-    return evaluate_node(
+    return evaluate_node(  # type: ignore
         value_word_node,
         context=NodeExecutionContext(environment=environment, input=value)
     )
 
 
-def evaluate_node(node, context):
+def evaluate_node(node, context):  # type: ignore
     if node.kind == 'word':
-        return evaluate_word_node(node, context=context)
+        return evaluate_word_node(node, context=context)  # type: ignore
     elif node.kind == 'commandsubstitution':
-        return evaluate_command_node(node.command, context=context)
+        return evaluate_command_node(node.command, context=context)  # type: ignore
     elif node.kind == 'parameter':
-        return evaluate_parameter_node(node, context=context)
+        return evaluate_parameter_node(node, context=context)  # type: ignore
     else:
         raise ValueError('Unsupported bash construct: "%s"' % node.word)
 
 
-def evaluate_word_node(node, context):
+def evaluate_word_node(node, context):  # type: ignore
     word_start = node.pos[0]
     word_end = node.pos[1]
     word_string = context.input[word_start:word_end]
@@ -51,7 +53,7 @@ def evaluate_word_node(node, context):
         for i in range(part_start, part_end):
             letters[i] = None
 
-        letters[part_start] = evaluate_node(part, context=context)
+        letters[part_start] = evaluate_node(part, context=context)  # type: ignore
 
     # remove the None letters and concat
     value = ''.join(l for l in letters if l is not None)
@@ -60,11 +62,11 @@ def evaluate_word_node(node, context):
     return ' '.join(word.strip() for word in shlex.split(value))
 
 
-def evaluate_command_node(node, context):
-    words = [evaluate_node(part, context=context) for part in node.parts]
+def evaluate_command_node(node, context):  # type: ignore
+    words = [evaluate_node(part, context=context) for part in node.parts]  # type: ignore
     command = ' '.join(words)
     return subprocess.check_output(shlex.split(command), env=context.environment, universal_newlines=True)
 
 
-def evaluate_parameter_node(node, context):
+def evaluate_parameter_node(node, context):  # type: ignore
     return context.environment.get(node.value, '')

--- a/cibuildwheel/bashlex_eval.py
+++ b/cibuildwheel/bashlex_eval.py
@@ -1,7 +1,7 @@
 import shlex
 import subprocess
 
-from typing import Dict, List, NamedTuple, Optional
+from typing import Dict, NamedTuple
 
 import bashlex  # type: ignore
 
@@ -45,7 +45,7 @@ def evaluate_word_node(node: bashlex.ast.node, context: NodeExecutionContext) ->
     word_start = node.pos[0]
     word_end = node.pos[1]
     word_string = context.input[word_start:word_end]
-    letters: List[Optional[str]] = list(word_string)
+    letters = list(word_string)
 
     for part in node.parts:
         part_start = part.pos[0] - word_start
@@ -53,12 +53,12 @@ def evaluate_word_node(node: bashlex.ast.node, context: NodeExecutionContext) ->
 
         # Set all the characters in the part to None
         for i in range(part_start, part_end):
-            letters[i] = None
+            letters[i] = ''
 
         letters[part_start] = evaluate_node(part, context=context)
 
     # remove the None letters and concat
-    value = ''.join(l for l in letters if l is not None)
+    value = ''.join(letters)
 
     # apply bash-like quotes/whitespace treatment
     return ' '.join(word.strip() for word in shlex.split(value))

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -43,7 +43,10 @@ def matches_platform(identifier: str) -> bool:
     return False
 
 
-PythonConfiguration = NamedTuple('PythonConfiguration', [('version', str), ('identifier', str), ('path', str)])
+class PythonConfiguration(NamedTuple):
+    version: str
+    identifier: str
+    path: str
 
 
 def get_python_configurations(build_selector: Callable[[str], bool]) -> List[PythonConfiguration]:

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -5,13 +5,9 @@ import subprocess
 import sys
 import textwrap
 import uuid
-from collections import namedtuple
 
-from typing import Callable, Dict, List, Optional
+from typing import Callable, List, NamedTuple
 
-from .environment import (
-    ParsedEnvironment,
-)
 from .util import (
     BuildOptions,
     get_build_verbosity_extra_flags,
@@ -47,7 +43,7 @@ def matches_platform(identifier):
     return False
 
 
-PythonConfiguration = namedtuple('PythonConfiguration', ['version', 'identifier', 'path'])
+PythonConfiguration = NamedTuple('PythonConfiguration', [('version', str), ('identifier', str), ('path', str)])
 
 
 def get_python_configurations(build_selector: Callable[[str], bool]) -> List[PythonConfiguration]:

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -6,7 +6,7 @@ import sys
 import textwrap
 import uuid
 
-from typing import Callable, List, NamedTuple
+from typing import Callable, List, NamedTuple, Optional, Union
 
 from .util import (
     BuildOptions,
@@ -15,14 +15,14 @@ from .util import (
 )
 
 
-def call(args, input=None, universal_newlines=False):
+def call(args: List[str], input: Optional[Union[str, bytes]] = None, universal_newlines: bool = False) -> None:
     print('+ ' + ' '.join(shlex.quote(a) for a in args))
     subprocess.run(
         args, input=input, universal_newlines=universal_newlines, check=True
     )
 
 
-def matches_platform(identifier):
+def matches_platform(identifier: str) -> bool:
     pm = platform.machine()
     if pm == "x86_64":
         # x86_64 machines can run i686 docker containers
@@ -79,7 +79,7 @@ def get_python_configurations(build_selector: Callable[[str], bool]) -> List[Pyt
     return [c for c in python_configurations if matches_platform(c.identifier) and build_selector(c.identifier)]
 
 
-def build(options: BuildOptions):
+def build(options: BuildOptions) -> None:
     try:
         subprocess.check_call(['docker', '--version'])
     except Exception:

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -6,10 +6,11 @@ import sys
 import textwrap
 import uuid
 
-from typing import Callable, List, NamedTuple, Optional, Union
+from typing import List, NamedTuple, Optional, Union
 
 from .util import (
     BuildOptions,
+    BuildSelector,
     get_build_verbosity_extra_flags,
     prepare_command,
 )
@@ -49,7 +50,7 @@ class PythonConfiguration(NamedTuple):
     path: str
 
 
-def get_python_configurations(build_selector: Callable[[str], bool]) -> List[PythonConfiguration]:
+def get_python_configurations(build_selector: BuildSelector) -> List[PythonConfiguration]:
     python_configurations = [
         PythonConfiguration(version='2.7', identifier='cp27-manylinux_x86_64', path='/opt/python/cp27-cp27m'),
         PythonConfiguration(version='2.7', identifier='cp27-manylinux_x86_64', path='/opt/python/cp27-cp27mu'),

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -28,7 +28,10 @@ def call(args: Union[str, List[str]], env: Optional[Dict[str, str]] = None, cwd:
     return subprocess.check_call(args, env=env, cwd=cwd, shell=shell)
 
 
-PythonConfiguration = NamedTuple('PythonConfiguration', [('version', str), ('identifier', str), ('url', str)])
+class PythonConfiguration(NamedTuple):
+    version: str
+    identifier: str
+    url: str
 
 
 def get_python_configurations(build_selector: Callable[[str], bool]) -> List[PythonConfiguration]:

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -4,14 +4,10 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from collections import namedtuple
 from glob import glob
 
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, NamedTuple, Union
 
-from .environment import (
-    ParsedEnvironment,
-)
 from .util import (
     BuildOptions,
     download,
@@ -31,7 +27,7 @@ def call(args: Union[str, List[str]], env: Optional[Dict[str, str]] = None, cwd:
     return subprocess.check_call(args, env=env, cwd=cwd, shell=shell)
 
 
-PythonConfiguration = namedtuple('PythonConfiguration', ['version', 'identifier', 'url'])
+PythonConfiguration = NamedTuple('PythonConfiguration', [('version', str), ('identifier', str), ('url', str)])
 
 
 def get_python_configurations(build_selector: Callable[[str], bool]) -> List[PythonConfiguration]:

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -6,11 +6,12 @@ import sys
 import tempfile
 from glob import glob
 
-from typing import Callable, Dict, List, Optional, NamedTuple, Union
+from typing import Dict, List, Optional, NamedTuple, Union
 
 from .environment import ParsedEnvironment
 from .util import (
     BuildOptions,
+    BuildSelector,
     download,
     get_build_verbosity_extra_flags,
     get_pip_script,
@@ -34,7 +35,7 @@ class PythonConfiguration(NamedTuple):
     url: str
 
 
-def get_python_configurations(build_selector: Callable[[str], bool]) -> List[PythonConfiguration]:
+def get_python_configurations(build_selector: BuildSelector) -> List[PythonConfiguration]:
     python_configurations = [
         # CPython
         PythonConfiguration(version='2.7', identifier='cp27-macosx_x86_64', url='https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg'),

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -8,6 +8,7 @@ from glob import glob
 
 from typing import Callable, Dict, List, Optional, NamedTuple, Union
 
+from .environment import ParsedEnvironment
 from .util import (
     BuildOptions,
     download,
@@ -106,7 +107,7 @@ def install_pypy(version: str, url: str) -> str:
     return installation_bin_path
 
 
-def setup_python(python_configuration, dependency_constraint_flags, environment):
+def setup_python(python_configuration: PythonConfiguration, dependency_constraint_flags: List[str], environment: ParsedEnvironment) -> Dict[str, str]:
     if python_configuration.identifier.startswith('cp'):
         installation_bin_path = install_cpython(python_configuration.version, python_configuration.url)
     elif python_configuration.identifier.startswith('pp'):
@@ -164,7 +165,7 @@ def setup_python(python_configuration, dependency_constraint_flags, environment)
     return env
 
 
-def build(options: BuildOptions):
+def build(options: BuildOptions) -> None:
     temp_dir = tempfile.mkdtemp(prefix='cibuildwheel')
     built_wheel_dir = os.path.join(temp_dir, 'built_wheel')
     repaired_wheel_dir = os.path.join(temp_dir, 'repaired_wheel')

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -3,7 +3,7 @@ import urllib.request
 from fnmatch import fnmatch
 from time import sleep
 
-from typing import Dict, List, NamedTuple, Optional, Type, TypeVar
+from typing import Dict, List, NamedTuple, Optional
 
 from .environment import ParsedEnvironment
 
@@ -82,17 +82,14 @@ def download(url: str, dest: str) -> None:
         response.close()
 
 
-DependencyConstraints_T = TypeVar('DependencyConstraints_T', bound='DependencyConstraints')
-
-
 class DependencyConstraints:
     def __init__(self, base_file_path: str):
         assert os.path.exists(base_file_path)
         self.base_file_path = os.path.abspath(base_file_path)
 
-    @classmethod
-    def with_defaults(cls: Type[DependencyConstraints_T]) -> DependencyConstraints_T:
-        return cls(
+    @staticmethod
+    def with_defaults() -> 'DependencyConstraints':
+        return DependencyConstraints(
             base_file_path=os.path.join(os.path.dirname(__file__), 'resources', 'constraints.txt')
         )
 

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -2,12 +2,13 @@ import os
 import urllib.request
 from fnmatch import fnmatch
 from time import sleep
-from typing import NamedTuple, List, Optional, Dict
+
+from typing import Dict, List, NamedTuple, Optional
 
 from .environment import ParsedEnvironment
 
 
-def prepare_command(command, **kwargs):
+def prepare_command(command: str, **kwargs: str) -> str:
     '''
     Preprocesses a command by expanding variables like {python}.
 
@@ -17,7 +18,7 @@ def prepare_command(command, **kwargs):
     return command.format(python='python', pip='pip', **kwargs)
 
 
-def get_build_verbosity_extra_flags(level):
+def get_build_verbosity_extra_flags(level: int) -> List[str]:
     if level > 0:
         return ['-' + level * 'v']
     elif level < 0:
@@ -27,37 +28,37 @@ def get_build_verbosity_extra_flags(level):
 
 
 class BuildSelector:
-    def __init__(self, build_config, skip_config):
+    def __init__(self, build_config: str, skip_config: str):
         self.build_patterns = build_config.split()
         self.skip_patterns = skip_config.split()
 
-    def __call__(self, build_id):
-        def match_any(patterns):
+    def __call__(self, build_id: str) -> bool:
+        def match_any(patterns: List[str]) -> bool:
             return any(fnmatch(build_id, pattern) for pattern in patterns)
         return match_any(self.build_patterns) and not match_any(self.skip_patterns)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'BuildSelector({!r} - {!r})'.format(' '.join(self.build_patterns), ' '.join(self.skip_patterns))
 
 
 # Taken from https://stackoverflow.com/a/107717
 class Unbuffered:
-    def __init__(self, stream):
+    def __init__(self, stream):  # type: ignore
         self.stream = stream
 
-    def write(self, data):
+    def write(self, data):  # type: ignore
         self.stream.write(data)
         self.stream.flush()
 
-    def writelines(self, datas):
+    def writelines(self, datas):  # type: ignore
         self.stream.writelines(datas)
         self.stream.flush()
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr):  # type: ignore
         return getattr(self.stream, attr)
 
 
-def download(url, dest):
+def download(url: str, dest: str) -> None:
     print('+ Download ' + url + ' to ' + dest)
     dest_dir = os.path.dirname(dest)
     if not os.path.exists(dest_dir):

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -3,7 +3,7 @@ import urllib.request
 from fnmatch import fnmatch
 from time import sleep
 
-from typing import Dict, List, NamedTuple, Optional
+from typing import Dict, List, NamedTuple, Optional, Type, TypeVar
 
 from .environment import ParsedEnvironment
 
@@ -82,18 +82,21 @@ def download(url: str, dest: str) -> None:
         response.close()
 
 
+DependencyConstraints_T = TypeVar('DependencyConstraints_T', bound='DependencyConstraints')
+
+
 class DependencyConstraints:
-    def __init__(self, base_file_path):
+    def __init__(self, base_file_path: str):
         assert os.path.exists(base_file_path)
         self.base_file_path = os.path.abspath(base_file_path)
 
     @classmethod
-    def with_defaults(cls):
+    def with_defaults(cls: Type[DependencyConstraints_T]) -> DependencyConstraints_T:
         return cls(
             base_file_path=os.path.join(os.path.dirname(__file__), 'resources', 'constraints.txt')
         )
 
-    def get_for_python_version(self, version):
+    def get_for_python_version(self, version: str) -> str:
         version_parts = version.split('.')
 
         # try to find a version-specific dependency file e.g. if

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -110,26 +110,21 @@ class DependencyConstraints:
             return self.base_file_path
 
 
-BuildOptions = NamedTuple("BuildOptions", [
-    ("package_dir", str),
-    ("output_dir", str),
-    ("test_command", Optional[str]),
-    ("test_requires", List[str]),
-    ("test_extras", str),
-    ("before_build", Optional[str]),
-    ("build_verbosity", int),
-    ("build_selector", BuildSelector),
-    ("repair_command", str),
-    ("environment", ParsedEnvironment),
-    ("before_test", str),
-    ("dependency_constraints", Optional[DependencyConstraints]),
-    ("manylinux_images", Optional[Dict[str, str]]),
-])
+class BuildOptions(NamedTuple):
+    package_dir: str
+    output_dir: str
+    test_command: Optional[str]
+    test_requires: List[str]
+    test_extras: str
+    before_build: Optional[str]
+    build_verbosity: int
+    build_selector: BuildSelector
+    repair_command: str
+    environment: ParsedEnvironment
+    before_test: str
+    dependency_constraints: Optional[DependencyConstraints]
+    manylinux_images: Optional[Dict[str, str]]
 
-"""
-Replace this definition with a class-style NamedTuple in the
-PEP526 style when Python 3.5 host support is dropped
-"""
 
 resources_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'resources'))
 get_pip_script = os.path.join(resources_dir, 'get-pip.py')

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -82,9 +82,8 @@ def install_cpython(version: str, arch: str, nuget: str) -> str:
     return installation_path
 
 
-def install_pypy(version: str, arch: str, url: Optional[str]) -> str:
+def install_pypy(version: str, arch: str, url: str) -> str:
     assert arch == '32'
-    assert url is not None
     # Inside the PyPy zip file is a directory with the same name
     zip_filename = url.rsplit('/', 1)[-1]
     installation_path = os.path.join('C:\\cibw', os.path.splitext(zip_filename)[0])
@@ -106,6 +105,7 @@ def setup_python(python_configuration: PythonConfiguration, dependency_constrain
     if python_configuration.identifier.startswith('cp'):
         installation_path = install_cpython(python_configuration.version, python_configuration.arch, nuget)
     elif python_configuration.identifier.startswith('pp'):
+        assert python_configuration.url is not None
         installation_path = install_pypy(python_configuration.version, python_configuration.arch, python_configuration.url)
     else:
         raise ValueError("Unknown Python implementation")

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -8,6 +8,7 @@ from zipfile import ZipFile
 
 from typing import Callable, Dict, List, Optional, NamedTuple
 
+from .environment import ParsedEnvironment
 from .util import (
     BuildOptions,
     download,
@@ -93,7 +94,7 @@ def install_pypy(version: str, arch: str, url: Optional[str]) -> str:
     return installation_path
 
 
-def setup_python(python_configuration, dependency_constraint_flags, environment):
+def setup_python(python_configuration: PythonConfiguration, dependency_constraint_flags: List[str], environment: ParsedEnvironment) -> Dict[str, str]:
     nuget = 'C:\\cibw\\nuget.exe'
     if not os.path.exists(nuget):
         download('https://dist.nuget.org/win-x86-commandline/latest/nuget.exe', nuget)
@@ -145,7 +146,7 @@ def setup_python(python_configuration, dependency_constraint_flags, environment)
     return env
 
 
-def build(options: BuildOptions):
+def build(options: BuildOptions) -> None:
     temp_dir = tempfile.mkdtemp(prefix='cibuildwheel')
     built_wheel_dir = os.path.join(temp_dir, 'built_wheel')
     repaired_wheel_dir = os.path.join(temp_dir, 'repaired_wheel')

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -34,7 +34,11 @@ def get_nuget_args(version: str, arch: str) -> List[str]:
     return [python_name, '-Version', version, '-OutputDirectory', 'C:\\cibw\\python']
 
 
-PythonConfiguration = NamedTuple('PythonConfiguration', [('version', str), ('arch', str), ('identifier', str), ('url', Optional[str])])
+class PythonConfiguration(NamedTuple):
+    version: str
+    arch: str
+    identifier: str
+    url: Optional[str]
 
 
 def get_python_configurations(build_selector: Callable[[str], bool]) -> List[PythonConfiguration]:

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -3,15 +3,11 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from collections import namedtuple
 from glob import glob
 from zipfile import ZipFile
 
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, NamedTuple
 
-from .environment import (
-    ParsedEnvironment,
-)
 from .util import (
     BuildOptions,
     download,
@@ -37,7 +33,7 @@ def get_nuget_args(version: str, arch: str) -> List[str]:
     return [python_name, '-Version', version, '-OutputDirectory', 'C:\\cibw\\python']
 
 
-PythonConfiguration = namedtuple('PythonConfiguration', ['version', 'arch', 'identifier', 'url'])
+PythonConfiguration = NamedTuple('PythonConfiguration', [('version', str), ('arch', str), ('identifier', str), ('url', Optional[str])])
 
 
 def get_python_configurations(build_selector: Callable[[str], bool]) -> List[PythonConfiguration]:
@@ -81,8 +77,9 @@ def install_cpython(version: str, arch: str, nuget: str) -> str:
     return installation_path
 
 
-def install_pypy(version: str, arch: str, url: str) -> str:
+def install_pypy(version: str, arch: str, url: Optional[str]) -> str:
     assert arch == '32'
+    assert url is not None
     # Inside the PyPy zip file is a directory with the same name
     zip_filename = url.rsplit('/', 1)[-1]
     installation_path = os.path.join('C:\\cibw', os.path.splitext(zip_filename)[0])

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -6,11 +6,12 @@ import tempfile
 from glob import glob
 from zipfile import ZipFile
 
-from typing import Callable, Dict, List, Optional, NamedTuple
+from typing import Dict, List, Optional, NamedTuple
 
 from .environment import ParsedEnvironment
 from .util import (
     BuildOptions,
+    BuildSelector,
     download,
     get_build_verbosity_extra_flags,
     get_pip_script,
@@ -41,7 +42,7 @@ class PythonConfiguration(NamedTuple):
     url: Optional[str]
 
 
-def get_python_configurations(build_selector: Callable[[str], bool]) -> List[PythonConfiguration]:
+def get_python_configurations(build_selector: BuildSelector) -> List[PythonConfiguration]:
     python_configurations = [
         # CPython
         PythonConfiguration(version='2.7.18', arch='32', identifier='cp27-win32', url=None),

--- a/examples/travis-ci-test-and-deploy.yml
+++ b/examples/travis-ci-test-and-deploy.yml
@@ -7,7 +7,6 @@
 
 language: python
 python:
-  - 3.5
   - 3.6
   - 3.7
   - 3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,7 @@ exclude =
   env??/,
   .venv/,
   site/
+
+[mypy]
+files=cibuildwheel/
+strict=True

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'cibuildwheel': ['resources/*'],
     },
     # Supported python versions
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     keywords='ci wheel packaging pypi travis appveyor macos linux windows',
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Finally pushing this, after this came up again in #307. As noted, this is based on an old version of master, before a bunch of refactoring PRs were merged, so it still needs to be rebased (which might be as hard as just doing it from scratch again?).

To check, install mypy and run `mypy --strict cibuildwheel/`.

Mainly meant to open the discussion of which aspects of type annoations are useful in the context of cibuildwheel and which are probably not. Python's typing is not all or nothing, so we can surely find middle ground.

@joerick, @Czaki, I think you were both interested to see this? :-)

EDIT:
Closes #258