### PR TITLE
Travis-CI Example: Fix aarch64

### DIFF
--- a/examples/travis-ci-minimal.yml
+++ b/examples/travis-ci-minimal.yml
@@ -6,7 +6,7 @@ jobs:
     - services: docker
     # perform a linux ARMv8 build
     - services: docker
-      arch: aarch64
+      arch: arm64
     # perform a linux PPC64LE build
     - services: docker
       arch: ppc64le


### PR DESCRIPTION
Thank you for the amazing `cibuildwheel`! :rocket: :sparkles: 

The `arch:` `aarch64` is called `arm64` on Travis-CI.
https://docs.travis-ci.com/user/multi-cpu-architectures/

Otherwise this falls back to a generic Linux amd64 host.