### PR TITLE
Enable pymdownx.magiclink to get automatic links for URLs in the Markdown docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,8 @@ markdown_extensions:
       permalink: True
   - attr_list
   - admonition
+  - pymdownx.magiclink:
+      repo_url_shortener: True
 
 plugins:
   - importmarkdown

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 -e ./docs/mkdocs_include_markdown_plugin
 pytest
 mkdocs==1.0.4
+pymdown-extensions
 pip-tools
 requests
 click


### PR DESCRIPTION
I always expected URLs to be turned into hyperlinks (like on GitHub and in my IDE Markdown editors), but I noticed again that MkDocs (using Python-Markdown) doesn't do this (see e.g. https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/).

Installing and enabling this extension fixes that (and even shortens links to GitHub issues, etc, if enabled; see https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/ for details on what else can be configured).

The alternative is adding `<...>` around bare links and wouldn't require an extra extension, but that seems a lot easier to forget to me.