### PR TITLE
add linux32 to i686 builds

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -109,13 +109,14 @@ def build(options: BuildOptions):
         container_name = 'cibuildwheel-{}'.format(uuid.uuid4())
 
         try:
+            process_name = 'linux32 /bin/bash' if platform_tag.endswith("i686") else '/bin/bash'
             call(['docker', 'create',
                   '--env', 'CIBUILDWHEEL',
                   '--name', container_name,
                   '-i',
                   '-v', '/:/host',  # ignored on CircleCI
                   docker_image,
-                  '/bin/bash'])
+                  process_name])
 
             call(['docker', 'cp', '.', container_name + ':/project'])
 
@@ -136,7 +137,7 @@ def build(options: BuildOptions):
                         )
 
                 call(
-                    ['docker', 'exec', '-i', container_name, '/bin/bash'],
+                    ['docker', 'exec', '-i', container_name, process_name],
                     universal_newlines=True,
                     input='''
                         # give xtrace output an extra level of indent inside docker

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -109,7 +109,7 @@ def build(options: BuildOptions):
         container_name = 'cibuildwheel-{}'.format(uuid.uuid4())
 
         try:
-            process_name = 'linux32 /bin/bash' if platform_tag.endswith("i686") else '/bin/bash'
+            shell_cmd = ['linux32', '/bin/bash'] if platform_tag.endswith("i686") else ['/bin/bash']
             call(['docker', 'create',
                   '--env', 'CIBUILDWHEEL',
                   '--name', container_name,
@@ -137,7 +137,7 @@ def build(options: BuildOptions):
                         )
 
                 call(
-                    ['docker', 'exec', '-i', container_name] + process_name.split(" "),
+                    ['docker', 'exec', '-i', container_name] + shell_cmd,
                     universal_newlines=True,
                     input='''
                         # give xtrace output an extra level of indent inside docker

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -116,7 +116,7 @@ def build(options: BuildOptions):
                   '-i',
                   '-v', '/:/host',  # ignored on CircleCI
                   docker_image,
-                  process_name])
+                  '/bin/bash'])
 
             call(['docker', 'cp', '.', container_name + ':/project'])
 
@@ -137,7 +137,7 @@ def build(options: BuildOptions):
                         )
 
                 call(
-                    ['docker', 'exec', '-i', container_name, process_name],
+                    ['docker', 'exec', '-i', container_name] + process_name.split(" "),
                     universal_newlines=True,
                     input='''
                         # give xtrace output an extra level of indent inside docker

--- a/test/02_test/test/spam_test.py
+++ b/test/02_test/test/spam_test.py
@@ -53,4 +53,4 @@ class TestSpam(TestCase):
         # See #336 for more info.
         bits = struct.calcsize("P") * 8
         if bits == 32:
-            self.assertEqual(os.uname()[4], "i686")
+            self.assertEqual(platform.machine(), "i686")

--- a/test/02_test/test/spam_test.py
+++ b/test/02_test/test/spam_test.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 import os
+import platform
 import sys
+import struct
 from unittest import TestCase
 
 import spam
@@ -43,3 +45,10 @@ class TestSpam(TestCase):
             print("=[listdir]2", os.listdir(os.path.join(virtualenv_path, 'bin')))
         self.assertTrue(path_contains(virtualenv_path, sys.executable))
         self.assertTrue(path_contains(virtualenv_path, spam.__file__))
+
+    def test_uname(self):
+        if platform.system() == "Windows":
+            return
+        bits = struct.calcsize("P") * 8
+        if bits == 32:
+            self.assertEqual(os.uname()[4], "i686")

--- a/test/02_test/test/spam_test.py
+++ b/test/02_test/test/spam_test.py
@@ -49,6 +49,8 @@ class TestSpam(TestCase):
     def test_uname(self):
         if platform.system() == "Windows":
             return
+        # if we're running in 32-bit Python, check that the machine is i686.
+        # See #336 for more info.
         bits = struct.calcsize("P") * 8
         if bits == 32:
             self.assertEqual(os.uname()[4], "i686")


### PR DESCRIPTION
Docker exex does not use entrypoint when using exec

https://stackoverflow.com/questions/43723777/how-to-execute-the-entrypoint-of-a-docker-images-at-each-exec-command

found in #336 