### PR TITLE
Use f-strings

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -38,7 +38,7 @@ def get_option_from_environment(option_name: str, platform: Optional[str] = None
       CIBW_COLOR.
     '''
     if platform:
-        option = os.environ.get('%s_%s' % (option_name, platform.upper()))
+        option = os.environ.get(f'{option_name}_{platform.upper()}')
         if option is not None:
             return option
 
@@ -141,7 +141,7 @@ def main() -> None:
         dependency_constraints = DependencyConstraints(dependency_versions)
 
     if test_extras:
-        test_extras = '[{0}]'.format(test_extras)
+        test_extras = f'[{test_extras}]'
 
     try:
         build_verbosity = min(3, max(-3, int(build_verbosity_str)))
@@ -151,7 +151,7 @@ def main() -> None:
     try:
         environment = parse_environment(environment_config)
     except (EnvironmentParseError, ValueError):
-        print('cibuildwheel: Malformed environment option "%s"' % environment_config, file=sys.stderr)
+        print(f'cibuildwheel: Malformed environment option "{environment_config}"', file=sys.stderr)
         traceback.print_exc(None, sys.stderr)
         exit(2)
 
@@ -187,7 +187,7 @@ def main() -> None:
         for build_platform in ['x86_64', 'i686', 'pypy_x86_64', 'aarch64', 'ppc64le', 's390x']:
             pinned_images = all_pinned_docker_images[build_platform]
 
-            config_name = 'CIBW_MANYLINUX_{}_IMAGE'.format(build_platform.upper())
+            config_name = f'CIBW_MANYLINUX_{build_platform.upper()}_IMAGE'
             config_value = os.environ.get(config_name)
 
             if config_value is None:
@@ -231,7 +231,7 @@ def main() -> None:
     elif platform == 'macos':
         cibuildwheel.macos.build(build_options)
     else:
-        print('cibuildwheel: Unsupported platform: {}'.format(platform), file=sys.stderr)
+        print(f'cibuildwheel: Unsupported platform: {platform}', file=sys.stderr)
         exit(2)
 
 
@@ -240,12 +240,12 @@ def detect_obsolete_options() -> None:
     for (deprecated, alternative) in [('CIBW_MANYLINUX1_X86_64_IMAGE', 'CIBW_MANYLINUX_X86_64_IMAGE'),
                                       ('CIBW_MANYLINUX1_I686_IMAGE', 'CIBW_MANYLINUX_I686_IMAGE')]:
         if deprecated in os.environ:
-            print("'{}' has been deprecated, and will be removed in a future release. Use the option '{}' instead.".format(deprecated, alternative))
+            print(f"'{deprecated}' has been deprecated, and will be removed in a future release. Use the option '{alternative}' instead.")
             if alternative not in os.environ:
-                print("Using value of option '{}' as replacement for '{}'".format(deprecated, alternative))
+                print(f"Using value of option '{deprecated}' as replacement for '{alternative}'")
                 os.environ[alternative] = os.environ[deprecated]
             else:
-                print("Option '{}' is not empty. Please unset '{}'".format(alternative, deprecated))
+                print(f"Option '{alternative}' is not empty. Please unset '{deprecated}'")
                 exit(2)
 
     # Check for deprecated identifiers in 'CIBW_BUILD' and 'CIBW_SKIP' options
@@ -254,11 +254,7 @@ def detect_obsolete_options() -> None:
                                         ('macosx_10_6_intel', 'macosx_x86_64'),
                                         ('macosx_10_9_x86_64', 'macosx_x86_64')]:
             if option in os.environ and deprecated in os.environ[option]:
-                print("Build identifiers with '{deprecated}' have been deprecated. Replacing all occurences of '{deprecated}' with '{alternative}' in the option '{option}'".format(
-                    deprecated=deprecated,
-                    alternative=alternative,
-                    option=option,
-                ))
+                print(f"Build identifiers with '{deprecated}' have been deprecated. Replacing all occurences of '{deprecated}' with '{alternative}' in the option '{option}'")
                 os.environ[option] = os.environ[option].replace(deprecated, alternative)
 
 
@@ -270,12 +266,12 @@ def print_preamble(platform: str, build_options: BuildOptions) -> None:
         |___|_|___|___|_|_|___|_____|_|_|___|___|_|
         '''))
 
-    print('cibuildwheel version %s\n' % cibuildwheel.__version__)
+    print(f'cibuildwheel version {cibuildwheel.__version__}\n')
 
     print('Build options:')
-    print('  platform: %r' % platform)
+    print(f'  platform: {platform!r}')
     for option, value in sorted(build_options._asdict().items()):
-        print('  %s: %r' % (option, value))
+        print(f'  {option}: {value!r}')
 
     warnings = detect_warnings(platform, build_options)
     if warnings:

--- a/cibuildwheel/bashlex_eval.py
+++ b/cibuildwheel/bashlex_eval.py
@@ -20,7 +20,7 @@ def evaluate(value: str, environment: Dict[str, str]) -> str:
     command_node = bashlex.parsesingle(value)
 
     if len(command_node.parts) != 1:
-        raise ValueError('"%s" has too many parts' % value)
+        raise ValueError(f'"{value}" has too many parts')
 
     value_word_node = command_node.parts[0]
 
@@ -38,7 +38,7 @@ def evaluate_node(node: bashlex.ast.node, context: NodeExecutionContext) -> str:
     elif node.kind == 'parameter':
         return evaluate_parameter_node(node, context=context)
     else:
-        raise ValueError('Unsupported bash construct: "%s"' % node.word)
+        raise ValueError(f'Unsupported bash construct: "{node.word}"')
 
 
 def evaluate_word_node(node: bashlex.ast.node, context: NodeExecutionContext) -> str:

--- a/cibuildwheel/environment.py
+++ b/cibuildwheel/environment.py
@@ -51,10 +51,10 @@ class EnvironmentAssignment:
         return bashlex_eval.evaluate(self.value, environment=environment)
 
     def as_shell_assignment(self) -> str:
-        return 'export %s=%s' % (self.name, self.value)
+        return f'export {self.name}={self.value}'
 
     def __repr__(self) -> str:
-        return '%s=%s' % (self.name, self.value)
+        return f'{self.name}={self.value}'
 
 
 class ParsedEnvironment:
@@ -74,7 +74,7 @@ class ParsedEnvironment:
         return [a.as_shell_assignment() for a in self.assignments]
 
     def __repr__(self) -> str:
-        return 'ParsedEnvironment(%r)' % [repr(a) for a in self.assignments]
+        return f'ParsedEnvironment({[repr(a) for a in self.assignments]!r})'
 
 
 def parse_environment(env_string: str) -> ParsedEnvironment:

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -114,7 +114,7 @@ def build(options: BuildOptions) -> None:
         if not platform_configs:
             continue
 
-        container_name = 'cibuildwheel-{}'.format(uuid.uuid4())
+        container_name = f'cibuildwheel-{uuid.uuid4()}'
 
         try:
             shell_cmd = ['linux32', '/bin/bash'] if platform_tag.endswith("i686") else ['/bin/bash']

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -22,7 +22,7 @@ from .util import (
 def call(args: Union[str, List[str]], env: Optional[Dict[str, str]] = None, cwd: Optional[str] = None, shell: bool = False) -> int:
     # print the command executing for the logs
     if shell:
-        print('+ %s' % args)
+        print(f'+ {args}')
     else:
         print('+ ' + ' '.join(shlex.quote(a) for a in args))
 
@@ -74,7 +74,7 @@ def install_cpython(version: str, url: str) -> str:
     installed_system_packages = subprocess.check_output(['pkgutil', '--pkgs'], universal_newlines=True).splitlines()
 
     # if this version of python isn't installed, get it from python.org and install
-    python_package_identifier = 'org.python.Python.PythonFramework-{}'.format(version)
+    python_package_identifier = f'org.python.Python.PythonFramework-{version}'
     if python_package_identifier not in installed_system_packages:
         # download the pkg
         download(url, '/tmp/Python.pkg')
@@ -82,11 +82,11 @@ def install_cpython(version: str, url: str) -> str:
         call(['sudo', 'installer', '-pkg', '/tmp/Python.pkg', '-target', '/'])
         # patch open ssl
         if version == '3.5':
-            open_ssl_patch_url = 'https://github.com/mayeut/patch-macos-python-openssl/releases/download/v1.0.2u/patch-macos-python-%s-openssl-v1.0.2u.tar.gz' % version
+            open_ssl_patch_url = f'https://github.com/mayeut/patch-macos-python-openssl/releases/download/v1.0.2u/patch-macos-python-{version}-openssl-v1.0.2u.tar.gz'
             download(open_ssl_patch_url, '/tmp/python-patch.tar.gz')
-            call(['sudo', 'tar', '-C', '/Library/Frameworks/Python.framework/Versions/{}/'.format(version), '-xmf', '/tmp/python-patch.tar.gz'])
+            call(['sudo', 'tar', '-C', f'/Library/Frameworks/Python.framework/Versions/{version}/', '-xmf', '/tmp/python-patch.tar.gz'])
 
-    installation_bin_path = '/Library/Frameworks/Python.framework/Versions/{}/bin'.format(version)
+    installation_bin_path = f'/Library/Frameworks/Python.framework/Versions/{version}/bin'
     python_executable = 'python3' if version[0] == '3' else 'python'
     pip_executable = 'pip3' if version[0] == '3' else 'pip'
     make_symlinks(installation_bin_path, python_executable, pip_executable)

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -38,7 +38,7 @@ class BuildSelector:
         return match_any(self.build_patterns) and not match_any(self.skip_patterns)
 
     def __repr__(self) -> str:
-        return 'BuildSelector({!r} - {!r})'.format(' '.join(self.build_patterns), ' '.join(self.skip_patterns))
+        return f'BuildSelector({" ".join(self.build_patterns)!r} - {" ".join(self.skip_patterns)!r})'
 
 
 # Taken from https://stackoverflow.com/a/107717
@@ -99,7 +99,7 @@ class DependencyConstraints:
         # try to find a version-specific dependency file e.g. if
         # ./constraints.txt is the base, look for ./constraints-python27.txt
         base, ext = os.path.splitext(self.base_file_path)
-        specific = base + '-python{}{}'.format(version_parts[0], version_parts[1])
+        specific = base + f'-python{version_parts[0]}{version_parts[1]}'
         specific_file_path = specific + ext
         if os.path.exists(specific_file_path):
             return specific_file_path

--- a/test/12_dependency_versions/cibuildwheel_test.py
+++ b/test/12_dependency_versions/cibuildwheel_test.py
@@ -44,11 +44,11 @@ def test_pinned_versions(python_version):
     constraint_versions = get_versions_from_constraint_file(constraint_file)
 
     for package in ['pip', 'setuptools', 'wheel', 'virtualenv']:
-        env_name = 'EXPECTED_{}_VERSION'.format(package.upper())
+        env_name = f'EXPECTED_{package.upper()}_VERSION'
         build_environment[env_name] = constraint_versions[package]
 
     cibw_environment_option = ' '.join(
-        ['{}={}'.format(k, v) for k, v in build_environment.items()]
+        [f'{k}={v}' for k, v in build_environment.items()]
     )
 
     # build and test the wheels
@@ -100,11 +100,11 @@ def test_dependency_constraints_file(tmp_path, python_version):
     build_environment = {}
 
     for package_name, version in tool_versions.items():
-        env_name = 'EXPECTED_{}_VERSION'.format(package_name.upper())
+        env_name = f'EXPECTED_{package_name.upper()}_VERSION'
         build_environment[env_name] = version
 
     cibw_environment_option = ' '.join(
-        ['{}={}'.format(k, v) for k, v in build_environment.items()]
+        [f'{k}={v}' for k, v in build_environment.items()]
     )
 
     # build and test the wheels

--- a/test/shared/utils.py
+++ b/test/shared/utils.py
@@ -110,7 +110,7 @@ def expected_wheels(package_name, package_version, manylinux_versions=None,
                 architectures.append('i686')
 
             platform_tags = [
-                '{}_{}'.format(manylinux_version, architecture)
+                f'{manylinux_version}_{architecture}'
                 for architecture in architectures
                 for manylinux_version in manylinux_versions
             ]
@@ -122,16 +122,13 @@ def expected_wheels(package_name, package_version, manylinux_versions=None,
                 platform_tags = ['win32']
 
         elif platform == 'macos':
-            platform_tags = ['macosx_{}_x86_64'.format(macosx_deployment_target.replace('.', '_'))]
+            platform_tags = [f'macosx_{macosx_deployment_target.replace(".", "_")}_x86_64']
 
         else:
             raise Exception('unsupported platform')
 
         for platform_tag in platform_tags:
-            wheels.append('{package_name}-{package_version}-{python_abi_tag}-{platform_tag}.whl'.format(
-                package_name=package_name, package_version=package_version,
-                python_abi_tag=python_abi_tag, platform_tag=platform_tag
-            ))
+            wheels.append(f'{package_name}-{package_version}-{python_abi_tag}-{platform_tag}.whl')
 
     if IS_WINDOWS_RUNNING_ON_TRAVIS:
         # Python 2.7 isn't supported on Travis.

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -123,7 +123,7 @@ def test_repair_command(repair_command, platform_specific, platform, intercepted
 ])
 @pytest.mark.parametrize('platform_specific', [False, True])
 def test_environment(environment, platform_specific, platform, intercepted_build_args, monkeypatch):
-    env_string = ' '.join(['{}={}'.format(k, v) for k, v in environment.items()])
+    env_string = ' '.join([f'{k}={v}' for k, v in environment.items()])
     if platform_specific:
         monkeypatch.setenv('CIBW_ENVIRONMENT_' + platform.upper(), env_string)
         monkeypatch.setenv('CIBW_ENVIRONMENT', 'overwritten')


### PR DESCRIPTION
Now that minimum python supported is 3.6, we can use f-strings !

for tests, `setup.py` are not modified because running older python versions.

I left out 2 `.format(...)` I didn't see any interest in changing for now. 

Remaining `.format(...)` are in `linux.py`:
- in prepare_command function
- in the build function for the input string

xref #316 