### PR TITLE
Making order of options more consistent in docs and BuildOptions fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ Options
 |   | [`CIBW_BEFORE_BUILD`](https://cibuildwheel.readthedocs.io/en/stable/options/#before-build)  | Execute a shell command preparing each wheel's build |
 |   | [`CIBW_REPAIR_WHEEL_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#repair-wheel-command)  | Execute a shell command to repair each (non-pure Python) built wheel |
 |   | [`CIBW_MANYLINUX_X86_64_IMAGE`](https://cibuildwheel.readthedocs.io/en/stable/options/#manylinux-image)  [`CIBW_MANYLINUX_I686_IMAGE`](https://cibuildwheel.readthedocs.io/en/stable/options/#manylinux-image)  [`CIBW_MANYLINUX_PYPY_X86_64_IMAGE`](https://cibuildwheel.readthedocs.io/en/stable/options/#manylinux-image)  | Specify alternative manylinux docker images |
-| **Testing** | [`CIBW_TEST_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-command)  | Execute a shell command to test each built wheel |
-|   | [`CIBW_BEFORE_TEST`](https://cibuildwheel.readthedocs.io/en/stable/options/#before-test)  | Execute shell command to prepare test environment |
+| **Testing** | [`CIBW_BEFORE_TEST`](https://cibuildwheel.readthedocs.io/en/stable/options/#before-test)  | Execute shell command to prepare test environment |
 |   | [`CIBW_TEST_REQUIRES`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-requires)  | Install Python dependencies before running the tests |
 |   | [`CIBW_TEST_EXTRAS`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-extras)  | Install your wheel for testing using extras_require |
+|   | [`CIBW_TEST_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-command)  | Execute a shell command to test each built wheel |
 | **Other** | [`CIBW_BUILD_VERBOSITY`](https://cibuildwheel.readthedocs.io/en/stable/options/#build-verbosity)  | Increase/decrease the output of pip wheel |
 
 Working examples

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ Options
 |   | [`CIBW_BEFORE_BUILD`](https://cibuildwheel.readthedocs.io/en/stable/options/#before-build)  | Execute a shell command preparing each wheel's build |
 |   | [`CIBW_REPAIR_WHEEL_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#repair-wheel-command)  | Execute a shell command to repair each (non-pure Python) built wheel |
 |   | [`CIBW_MANYLINUX_X86_64_IMAGE`](https://cibuildwheel.readthedocs.io/en/stable/options/#manylinux-image)  [`CIBW_MANYLINUX_I686_IMAGE`](https://cibuildwheel.readthedocs.io/en/stable/options/#manylinux-image)  [`CIBW_MANYLINUX_PYPY_X86_64_IMAGE`](https://cibuildwheel.readthedocs.io/en/stable/options/#manylinux-image)  | Specify alternative manylinux docker images |
-| **Testing** | [`CIBW_BEFORE_TEST`](https://cibuildwheel.readthedocs.io/en/stable/options/#before-test)  | Execute shell command to prepare test environment |
+| **Testing** | [`CIBW_TEST_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-command)  | Execute a shell command to test each built wheel |
+|   | [`CIBW_BEFORE_TEST`](https://cibuildwheel.readthedocs.io/en/stable/options/#before-test)  | Execute shell command to prepare test environment |
 |   | [`CIBW_TEST_REQUIRES`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-requires)  | Install Python dependencies before running the tests |
 |   | [`CIBW_TEST_EXTRAS`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-extras)  | Install your wheel for testing using extras_require |
-|   | [`CIBW_TEST_COMMAND`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-command)  | Execute a shell command to test each built wheel |
 | **Other** | [`CIBW_BUILD_VERBOSITY`](https://cibuildwheel.readthedocs.io/en/stable/options/#build-verbosity)  | Increase/decrease the output of pip wheel |
 
 Working examples

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -115,9 +115,10 @@ def main() -> None:
             exit(2)
 
     output_dir = args.output_dir
-    test_command = get_option_from_environment('CIBW_TEST_COMMAND', platform=platform)
     test_requires = get_option_from_environment('CIBW_TEST_REQUIRES', platform=platform, default='').split()
     test_extras = get_option_from_environment('CIBW_TEST_EXTRAS', platform=platform, default='')
+    before_test = get_option_from_environment('CIBW_BEFORE_TEST', platform=platform, default='')
+    test_command = get_option_from_environment('CIBW_TEST_COMMAND', platform=platform)
     package_dir = args.package_dir
     before_build = get_option_from_environment('CIBW_BEFORE_BUILD', platform=platform)
     build_verbosity_str = get_option_from_environment('CIBW_BUILD_VERBOSITY', platform=platform, default='')
@@ -130,7 +131,6 @@ def main() -> None:
         repair_command_default = ''
     repair_command = get_option_from_environment('CIBW_REPAIR_WHEEL_COMMAND', platform=platform, default=repair_command_default)
     environment_config = get_option_from_environment('CIBW_ENVIRONMENT', platform=platform, default='')
-    before_test = get_option_from_environment('CIBW_BEFORE_TEST', platform=platform, default='')
 
     dependency_versions = get_option_from_environment('CIBW_DEPENDENCY_VERSIONS', platform=platform, default='pinned')
     if dependency_versions == 'pinned':

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -110,17 +110,17 @@ class DependencyConstraints:
 class BuildOptions(NamedTuple):
     package_dir: str
     output_dir: str
-    test_command: Optional[str]
+    build_selector: BuildSelector
+    environment: ParsedEnvironment
+    before_build: Optional[str]
+    repair_command: str
+    manylinux_images: Optional[Dict[str, str]]
+    dependency_constraints: Optional[DependencyConstraints]
+    before_test: str
     test_requires: List[str]
     test_extras: str
-    before_build: Optional[str]
+    test_command: Optional[str]
     build_verbosity: int
-    build_selector: BuildSelector
-    repair_command: str
-    environment: ParsedEnvironment
-    before_test: str
-    dependency_constraints: Optional[DependencyConstraints]
-    manylinux_images: Optional[Dict[str, str]]
 
 
 resources_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'resources'))

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -116,10 +116,10 @@ class BuildOptions(NamedTuple):
     repair_command: str
     manylinux_images: Optional[Dict[str, str]]
     dependency_constraints: Optional[DependencyConstraints]
-    before_test: str
+    test_command: Optional[str]
+    before_test: Optional[str]
     test_requires: List[str]
     test_extras: str
-    test_command: Optional[str]
     build_verbosity: int
 
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -52,7 +52,6 @@ env:
 
 ## Build selection
 
-
 ### `CIBW_PLATFORM` {: #platform}
 
 > Override the auto-detected target platform
@@ -66,6 +65,7 @@ Default: `auto`
 For `linux` you need Docker running, on macOS or Linux. For `macos`, you need a Mac machine, and note that this script is going to automatically install MacPython on your system, so don't run on your development machine. For `windows`, you need to run in Windows, and `cibuildwheel` will install required versions of Python to `C:\cibw\python` using NuGet.
 
 This option can also be set using the command-line option `--platform`.
+
 
 ### `CIBW_BUILD`, `CIBW_SKIP` {: #build-skip}
 
@@ -154,7 +154,6 @@ CIBW_SKIP: pp*
 
 
 ## Build customization
-
 
 ### `CIBW_ENVIRONMENT` {: #environment}
 > Set environment variables needed during the build
@@ -296,6 +295,7 @@ CIBW_MANYLINUX_X86_64_IMAGE: dockcross/manylinux-x64
 CIBW_MANYLINUX_I686_IMAGE: dockcross/manylinux-x86
 ```
 
+
 ### `CIBW_DEPENDENCY_VERSIONS` {: #dependency-versions}
 > Specify how cibuildwheel controls the versions of the tools it uses
 
@@ -348,27 +348,32 @@ CIBW_DEPENDENCY_VERSIONS: ./constraints.txt
 
 ## Testing
 
-### `CIBW_TEST_COMMAND` {: #test-command}
-> Execute a shell command to test each built wheel
+### `CIBW_BEFORE_TEST` {: #before-test}
+> Execute a shell command before testing each wheel
 
-Shell command to run tests after the build. The wheel will be installed automatically and available for import from the tests. To ensure the wheel is imported by your tests (instead of your source copy), tests are run from a different directory. Use the placeholders `{project}` and `{package}` when specifying paths in your project.
+A shell command to run in **each** test virtual environment, before your wheel is installed and tested. This is useful if you need to install a non pip package, change values of environment variables
+or perform multi step pip installation (e.g. installing `scikit-build` or `cython` before install test package)
 
-- `{project}` is an absolute path to the project root - the working directory where cibuildwheel was called.
-- `{package}` is the path to the package being built - the `package_dir` argument supplied to cibuildwheel on the command line.
+The active Python binary can be accessed using `python`, and pip with `pip`; `cibuildwheel` makes sure the right version of Python and pip will be executed. The placeholder `{package}` can be used here; it will be replaced by the path to the package being built by `cibuildwheel`.
 
 The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
 Platform-specific variants also available:<br/>
-`CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
+ `CIBW_BEFORE_TEST_MACOS` | `CIBW_BEFORE_TEST_WINDOWS` | `CIBW_BEFORE_TEST_LINUX`
 
 #### Examples
-
 ```yaml
-# run the project tests against the installed wheel using `nose`
-CIBW_TEST_COMMAND: nosetests {project}/tests
+# install test dependencies with overwritten environment variables.
+CIBW_BEFORE_TEST: CC=gcc CXX=g++ pip install -r requirements.txt
 
-# run the package tests using `pytest`
-CIBW_TEST_COMMAND: pytest {package}/tests
+# chain commands using &&
+CIBW_BEFORE_TEST: rm -rf ./data/cache && mkdir -p ./data/cache
+
+# install non pip python package
+CIBW_BEFORE_TEST: cd some_dir; ./configure; make; make install
+
+# install python packages that are required to install test dependencies
+CIBW_BEFORE_TEST: pip install cmake scikit-build
 ```
 
 
@@ -411,33 +416,30 @@ Platform-specific variants also available:<br/>
 CIBW_TEST_EXTRAS: test,qt
 ```
 
-### `CIBW_BEFORE_TEST` {: #before-test}
-> Execute a shell command before testing each wheel
 
-A shell command to run in **each** test virtual environment, before your wheel is installed and tested. This is useful if you need to install a non pip package, change values of environment variables
-or perform multi step pip installation (e.g. installing `scikit-build` or `cython` before install test package)
+### `CIBW_TEST_COMMAND` {: #test-command}
+> Execute a shell command to test each built wheel
 
-The active Python binary can be accessed using `python`, and pip with `pip`; `cibuildwheel` makes sure the right version of Python and pip will be executed. The placeholder `{package}` can be used here; it will be replaced by the path to the package being built by `cibuildwheel`.
+Shell command to run tests after the build. The wheel will be installed automatically and available for import from the tests. To ensure the wheel is imported by your tests (instead of your source copy), tests are run from a different directory. Use the placeholders `{project}` and `{package}` when specifying paths in your project.
+
+- `{project}` is an absolute path to the project root - the working directory where cibuildwheel was called.
+- `{package}` is the path to the package being built - the `package_dir` argument supplied to cibuildwheel on the command line.
 
 The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
 Platform-specific variants also available:<br/>
- `CIBW_BEFORE_TEST_MACOS` | `CIBW_BEFORE_TEST_WINDOWS` | `CIBW_BEFORE_TEST_LINUX`
+`CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
 
 #### Examples
+
 ```yaml
-# install test dependencies with overwritten environment variables.
-CIBW_BEFORE_TEST: CC=gcc CXX=g++ pip install -r requirements.txt
+# run the project tests against the installed wheel using `nose`
+CIBW_TEST_COMMAND: nosetests {project}/tests
 
-# chain commands using &&
-CIBW_BEFORE_TEST: rm -rf ./data/cache && mkdir -p ./data/cache
-
-# install non pip python package
-CIBW_BEFORE_TEST: cd some_dir; ./configure; make; make install
-
-# install python packages that are required to install test dependencies
-CIBW_BEFORE_TEST: pip install cmake scikit-build
+# run the package tests using `pytest`
+CIBW_TEST_COMMAND: pytest {package}/tests
 ```
+
 
 ## Other
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -348,6 +348,30 @@ CIBW_DEPENDENCY_VERSIONS: ./constraints.txt
 
 ## Testing
 
+### `CIBW_TEST_COMMAND` {: #test-command}
+> Execute a shell command to test each built wheel
+
+Shell command to run tests after the build. The wheel will be installed automatically and available for import from the tests. To ensure the wheel is imported by your tests (instead of your source copy), tests are run from a different directory. Use the placeholders `{project}` and `{package}` when specifying paths in your project.
+
+- `{project}` is an absolute path to the project root - the working directory where cibuildwheel was called.
+- `{package}` is the path to the package being built - the `package_dir` argument supplied to cibuildwheel on the command line.
+
+The command is run in a shell, so you can write things like `cmd1 && cmd2`.
+
+Platform-specific variants also available:<br/>
+`CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
+
+#### Examples
+
+```yaml
+# run the project tests against the installed wheel using `nose`
+CIBW_TEST_COMMAND: nosetests {project}/tests
+
+# run the package tests using `pytest`
+CIBW_TEST_COMMAND: pytest {package}/tests
+```
+
+
 ### `CIBW_BEFORE_TEST` {: #before-test}
 > Execute a shell command before testing each wheel
 
@@ -414,30 +438,6 @@ Platform-specific variants also available:<br/>
 ```yaml
 # will cause the wheel to be installed with `pip install <wheel_file>[test,qt]`
 CIBW_TEST_EXTRAS: test,qt
-```
-
-
-### `CIBW_TEST_COMMAND` {: #test-command}
-> Execute a shell command to test each built wheel
-
-Shell command to run tests after the build. The wheel will be installed automatically and available for import from the tests. To ensure the wheel is imported by your tests (instead of your source copy), tests are run from a different directory. Use the placeholders `{project}` and `{package}` when specifying paths in your project.
-
-- `{project}` is an absolute path to the project root - the working directory where cibuildwheel was called.
-- `{package}` is the path to the package being built - the `package_dir` argument supplied to cibuildwheel on the command line.
-
-The command is run in a shell, so you can write things like `cmd1 && cmd2`.
-
-Platform-specific variants also available:<br/>
-`CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
-
-#### Examples
-
-```yaml
-# run the project tests against the installed wheel using `nose`
-CIBW_TEST_COMMAND: nosetests {project}/tests
-
-# run the package tests using `pytest`
-CIBW_TEST_COMMAND: pytest {package}/tests
 ```
 
 


### PR DESCRIPTION
Reducing inconsistencies about the order in which options are applied.

Arguably, `CIBW_TEST_COMMAND` could be the first one withing the "Testing" section (as it's the central goal, and the others, `CIBW_TEST_REQUIRES`, `CIBW_TEST_EXTRA`, and `CIBW_BEFORE_TEST` wouldn't be there otherwise), though chronologically, it's the last thing happening.

Any thoughts? Is this too nitpicky?