### PR TITLE
Add test case for proper build isolation

### DIFF
--- a/cibuildwheel/resources/constraints-python27.txt
+++ b/cibuildwheel/resources/constraints-python27.txt
@@ -15,12 +15,12 @@ importlib-resources==1.5.0  # via virtualenv
 pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 scandir==1.10.0           # via pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
-six==1.14.0               # via pathlib2, virtualenv
+six==1.15.0               # via pathlib2, virtualenv
 typing==3.7.4.1           # via importlib-resources
-virtualenv==20.0.20       # via -r cibuildwheel/resources/constraints.in
+virtualenv==20.0.21       # via -r cibuildwheel/resources/constraints.in
 wheel==0.34.2             # via -r cibuildwheel/resources/constraints.in, delocate
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.1                 # via -r cibuildwheel/resources/constraints.in
+pip==20.1.1               # via -r cibuildwheel/resources/constraints.in
 setuptools==44.1.0        # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/constraints-python35.txt
+++ b/cibuildwheel/resources/constraints-python35.txt
@@ -10,11 +10,11 @@ distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via virtualenv
 importlib-metadata==1.6.0  # via importlib-resources, virtualenv
 importlib-resources==1.5.0  # via virtualenv
-six==1.14.0               # via virtualenv
-virtualenv==20.0.20       # via -r cibuildwheel/resources/constraints.in
+six==1.15.0               # via virtualenv
+virtualenv==20.0.21       # via -r cibuildwheel/resources/constraints.in
 wheel==0.34.2             # via -r cibuildwheel/resources/constraints.in, delocate
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.1                 # via -r cibuildwheel/resources/constraints.in
-setuptools==46.3.1        # via -r cibuildwheel/resources/constraints.in
+pip==20.1.1               # via -r cibuildwheel/resources/constraints.in
+setuptools==46.4.0        # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/constraints-python36.txt
+++ b/cibuildwheel/resources/constraints-python36.txt
@@ -10,11 +10,11 @@ distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via virtualenv
 importlib-metadata==1.6.0  # via importlib-resources, virtualenv
 importlib-resources==1.5.0  # via virtualenv
-six==1.14.0               # via virtualenv
-virtualenv==20.0.20       # via -r cibuildwheel/resources/constraints.in
+six==1.15.0               # via virtualenv
+virtualenv==20.0.21       # via -r cibuildwheel/resources/constraints.in
 wheel==0.34.2             # via -r cibuildwheel/resources/constraints.in, delocate
 zipp==3.1.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.1                 # via -r cibuildwheel/resources/constraints.in
-setuptools==46.3.1        # via -r cibuildwheel/resources/constraints.in
+pip==20.1.1               # via -r cibuildwheel/resources/constraints.in
+setuptools==46.4.0        # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/constraints.txt
+++ b/cibuildwheel/resources/constraints.txt
@@ -9,11 +9,11 @@ delocate==0.8.0           # via -r cibuildwheel/resources/constraints.in
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via virtualenv
 importlib-metadata==1.6.0  # via virtualenv
-six==1.14.0               # via virtualenv
-virtualenv==20.0.20       # via -r cibuildwheel/resources/constraints.in
+six==1.15.0               # via virtualenv
+virtualenv==20.0.21       # via -r cibuildwheel/resources/constraints.in
 wheel==0.34.2             # via -r cibuildwheel/resources/constraints.in, delocate
 zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.1                 # via -r cibuildwheel/resources/constraints.in
-setuptools==46.3.1        # via -r cibuildwheel/resources/constraints.in
+pip==20.1.1               # via -r cibuildwheel/resources/constraints.in
+setuptools==46.4.0        # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,22 +1,22 @@
 [x86_64]
-manylinux1 = quay.io/pypa/manylinux1_x86_64:2020-05-15-aad4e04
-manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2020-05-15-877bc09
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2020-05-15-5acda28
+manylinux1 = quay.io/pypa/manylinux1_x86_64:2020-05-25-b56702d
+manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2020-05-20-c7bbd11
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2020-05-17-2f8ac3b
 
 [i686]
-manylinux1 = quay.io/pypa/manylinux1_i686:2020-05-15-aad4e04
-manylinux2010 = quay.io/pypa/manylinux2010_i686:2020-05-15-877bc09
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2020-05-15-5acda28
+manylinux1 = quay.io/pypa/manylinux1_i686:2020-05-25-b56702d
+manylinux2010 = quay.io/pypa/manylinux2010_i686:2020-05-20-c7bbd11
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2020-05-17-2f8ac3b
 
 [pypy_x86_64]
 manylinux2010 = pypywheels/manylinux2010-pypy_x86_64:2020-04-25-eb2cdff
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2020-05-15-5acda28
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2020-05-17-2f8ac3b
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2020-05-15-5acda28
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2020-05-17-2f8ac3b
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2020-05-15-5acda28
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2020-05-17-2f8ac3b
 

--- a/test/test_unicode.py
+++ b/test/test_unicode.py
@@ -1,0 +1,31 @@
+import textwrap
+
+import pytest
+
+from . import utils
+from . import test_projects
+
+project_with_unicode = test_projects.new_c_project(
+    spam_c_function_add=textwrap.dedent(r'''
+        {
+            Py_XDECREF(PyUnicode_FromStringAndSize("foo", 4));
+        }
+    '''),
+)
+
+
+def test(tmp_path):
+    if utils.platform != 'linux':
+        pytest.skip('the docker test is only relevant to the linux build')
+
+    project_dir = tmp_path / 'project'
+    project_with_unicode.generate(project_dir)
+
+    # build the wheels
+    actual_wheels = utils.cibuildwheel_run(project_dir, add_env={
+        'CIBW_TEST_COMMAND': 'python -c "import spam"'
+    })
+
+    # check that the expected wheels are produced
+    expected_wheels = utils.expected_wheels('spam', '0.1.0')
+    assert set(actual_wheels) == set(expected_wheels)


### PR DESCRIPTION
If there's not a proper build isolation then, the wheel for `cp27mu` will pick up the `spam.so` built for `cp27m` resulting in an import error.