### PR TITLE
Adding PEP 518 test, fix 3.5 Python on Windows

### DIFF
--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -154,7 +154,7 @@ def setup_python(python_configuration: PythonConfiguration, dependency_constrain
     return env
 
 
-def pep_518_cp35_workaround(package_dir: str, env: Dict[str, str]) -> None:
+def pep_518_cp35_workaround(package_dir: Path, env: Dict[str, str]) -> None:
     """
     Python 3.5 PEP 518 hack (see https://github.com/pypa/pip/issues/8392#issuecomment-639563494)
     Basically, nuget's Python is an embedded Python distribution, which is not supported by pip.
@@ -166,9 +166,9 @@ def pep_518_cp35_workaround(package_dir: str, env: Dict[str, str]) -> None:
     mostly "isolated".
     """
 
-    pyproject_path = os.path.join(package_dir, 'pyproject.toml')
+    pyproject_path = package_dir / 'pyproject.toml'
 
-    if os.path.exists(pyproject_path):
+    if pyproject_path.exists():
         data = toml.load(pyproject_path)
         requirements = (
             data['build-system'].get('requires', [])

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -149,25 +149,32 @@ def setup_python(python_configuration: PythonConfiguration, dependency_constrain
     shell(['pip', '--version'], env=env)
     shell(['pip', 'install', '--upgrade', 'setuptools', 'wheel'] + dependency_constraint_flags, env=env)
 
-    # Python 3.5 PEP 518 hack (see https://github.com/pypa/pip/issues/8392#issuecomment-639563494)
-    # Basically, nuget's Python is an embedded Python distribution, which is not supported by pip.
-    # Before version 3.6, there was no way to disable the "embedded" behavior, including the ignoring
-    # of environment variables, including the ones pip uses to setup PEP 518 builds.
-    #
-    # The fix here is as suggested in that issue; we manually setup the PEP 518 requirements. Since we
-    # are in a fresh environment (except for pinned cibuildweel dependencies), the build is already
-    # mostly "isolated".
-    if python_configuration.version.startswith('3.5') and os.path.exists('pyproject.toml'):
-        data = toml.load('pyproject.toml')
+    return env
+
+
+def pep_518_cp35_workaround(package_dir: str, env: Dict[str, str]) -> None:
+    """
+    Python 3.5 PEP 518 hack (see https://github.com/pypa/pip/issues/8392#issuecomment-639563494)
+    Basically, nuget's Python is an embedded Python distribution, which is not supported by pip.
+    Before version 3.6, there was no way to disable the "embedded" behavior, including the ignoring
+    of environment variables, including the ones pip uses to setup PEP 518 builds.
+
+    The fix here is as suggested in that issue; we manually setup the PEP 518 requirements. Since we
+    are in a fresh environment (except for pinned cibuildweel dependencies), the build is already
+    mostly "isolated".
+    """
+
+    pyproject_path = os.path.join(package_dir, 'pyproject.toml')
+
+    if os.path.exists(pyproject_path):
+        data = toml.load(pyproject_path)
         requirements = (
             data['build-system'].get('requires', [])
             if 'build-system' in data
             else []
         )
         if requirements:
-            shell(['pip', 'install'] + requirements + dependency_constraint_flags, env=env)
-
-    return env
+            shell(['pip', 'install'] + requirements, env=env)
 
 
 def build(options: BuildOptions) -> None:
@@ -194,6 +201,11 @@ def build(options: BuildOptions) -> None:
         if options.before_build:
             before_build_prepared = prepare_command(options.before_build, project='.', package=options.package_dir)
             shell([before_build_prepared], env=env)
+
+        # activate the PEP 518 patch if on Windows Python 3.5
+        # (will only have an effect if PEP 517 builds are used):
+        if config.version.startswith('3.5'):
+            pep_518_cp35_workaround(options.package_dir, env)
 
         # build the wheel
         if os.path.exists(built_wheel_dir):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with io.open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 setup(
     name='cibuildwheel',
     version='1.4.2',
-    install_requires=['bashlex!=0.13'],
+    install_requires=['bashlex!=0.13', 'toml'],
     description="Build Python wheels on CI with minimal configuration.",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/test/test_pep518.py
+++ b/test/test_pep518.py
@@ -1,0 +1,44 @@
+import textwrap
+from . import test_projects
+from . import utils
+
+basic_project = test_projects.new_c_project(
+    setup_py_add=textwrap.dedent(
+        """
+        # Will fail if PEP 518 does work
+        import requests
+        assert requests.__version__ == "2.23.0", "Requests found but wrong version ({0})".format(requests.__version__)
+
+        # Just making sure environment is still set
+        import os
+        if os.environ.get("CIBUILDWHEEL", "0") != "1":
+            raise Exception("CIBUILDWHEEL environment variable is not set to 1")
+        """
+    )
+)
+
+basic_project.files[
+    "pyproject.toml"
+] = """
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "requests==2.23.0"
+]
+
+build-backend = "setuptools.build_meta"
+"""
+
+
+def test_pep518(tmp_path):
+
+    project_dir = tmp_path / "project"
+    basic_project.generate(project_dir)
+
+    # build the wheels
+    actual_wheels = utils.cibuildwheel_run(project_dir)
+
+    # check that the expected wheels are produced
+    expected_wheels = utils.expected_wheels("spam", "0.1.0")
+    assert set(actual_wheels) == set(expected_wheels)


### PR DESCRIPTION
As discussed in #350 

I'll fix the flake8 problem after the build. Wish this used pre-commit, I checked `pre-commit run` just to see.