### PR TITLE
example: for GH Actions use action to publish

### DIFF
--- a/examples/github-deployment.yml
+++ b/examples/github-deployment.yml
@@ -35,3 +35,13 @@ jobs:
       with:
         name: wheels
         path: ./wheelhouse
+
+    - name: Publish to PyPI
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master #see https://github.com/pypa/gh-action-pypi-publish for setup
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+        repository_url: https://test.pypi.org/legacy/ #TODO rm this line to use the "real" pypi
+        packages_dir: ./wheelhouse/
+

--- a/examples/github-deployment.yml
+++ b/examples/github-deployment.yml
@@ -1,4 +1,4 @@
-name: Build
+name: GH Deploy
 
 on: [push, pull_request]
 
@@ -36,7 +36,7 @@ jobs:
         name: wheels
         path: ./wheelhouse
 
-    - name: Publish to PyPI
+    - name: Publish to PyPI # (optional) automatically publish the whl to PyPI on a new tag/release
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master #see https://github.com/pypa/gh-action-pypi-publish for setup
       with:

--- a/examples/github-minimal.yml
+++ b/examples/github-minimal.yml
@@ -37,6 +37,7 @@ jobs:
         path: ./wheelhouse
 
     - name: Publish to PyPI
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master #see https://github.com/pypa/gh-action-pypi-publish for setup
       with:
         user: __token__

--- a/examples/github-minimal.yml
+++ b/examples/github-minimal.yml
@@ -35,3 +35,12 @@ jobs:
       with:
         name: wheels
         path: ./wheelhouse
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@master #see https://github.com/pypa/gh-action-pypi-publish for setup
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+        repository_url: https://test.pypi.org/legacy/ #TODO rm this line to use the "real" pypi
+        packages_dir: ./wheelhouse/
+


### PR DESCRIPTION
to PyPI, instead of calling twine directly.

Fixes #361 