### PR TITLE
Ignore errors when cleaning up docker container in linux.py

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -279,7 +279,10 @@ def build(options: BuildOptions) -> None:
             exit(1)
         finally:
             # Still gets executed, even when 'exit(1)' gets called
-            call(['docker', 'rm', '--force', '-v', container_name])
+            try:
+                call(['docker', 'rm', '--force', '-v', container_name])
+            except subprocess.CalledProcessError:
+                pass
 
 
 def troubleshoot(package_dir: str, error: Exception) -> None:


### PR DESCRIPTION
See discussion in #357 and https://github.com/joerick/cibuildwheel/issues/357#issuecomment-635613056

Not entirely convinced this is the perfect solution, though, as we would also be ignoring other errors and mistakes in future commits (when e.g. a wrong container name is passed or so). One solution would be to still print the error message.

We could also make this more slightly more complex by setting `docker_image_created = True` after the `docker create` call, and only ignore the error if it's not created?

Tagging @Czaki after the discussion in #357.