### PR TITLE
Simplify virtualenv test in test_testing

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -200,7 +200,6 @@ def build(options: BuildOptions) -> None:
                             pip install {dependency_install_flags} virtualenv
                             venv_dir=`mktemp -d`/venv
                             python -m virtualenv --no-download "$venv_dir"
-                            export __CIBW_VIRTUALENV_PATH__=$venv_dir
 
                             # run the tests in a subshell to keep that `activate`
                             # script from polluting the env

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -224,7 +224,6 @@ def build(options: BuildOptions) -> None:
                 os.path.join(venv_dir, 'bin'),
                 virtualenv_env['PATH'],
             ])
-            virtualenv_env["__CIBW_VIRTUALENV_PATH__"] = venv_dir
 
             # check that we are using the Python from the virtual environment
             call(['which', 'python'], env=virtualenv_env)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -206,13 +206,10 @@ def build(options: BuildOptions) -> None:
             shell(['python', '-m', 'virtualenv', '--no-download', venv_dir], env=env)
 
             virtualenv_env = env.copy()
-
-            venv_script_path = os.path.join(venv_dir, 'Scripts')
             virtualenv_env['PATH'] = os.pathsep.join([
-                venv_script_path,
+                os.path.join(venv_dir, 'Scripts'),
                 virtualenv_env['PATH'],
             ])
-            virtualenv_env["__CIBW_VIRTUALENV_PATH__"] = venv_dir
 
             # check that we are using the Python from the virtual environment
             shell(['which', 'python'], env=virtualenv_env)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -46,12 +46,15 @@ class TestSpam(TestCase):
         self.assertNotEqual(0, spam.system('python -c "exit(1)"'))
 
     def test_virtualenv(self):
-        virtualenv_path = os.environ.get("__CIBW_VIRTUALENV_PATH__")
-        if not virtualenv_path:
-            self.fail("No virtualenv path defined in environment variable __CIBW_VIRTUALENV_PATH__")
+        # sys.prefix is different from sys.base_prefix when running a virtualenv
+        # See https://docs.python.org/3/library/venv.html, which virtualenv seems
+        # to honor in recent releases
+        # Python 2 doesn't have sys.base_prefix by default
+        if not hasattr(sys, 'base_prefix') or sys.prefix == sys.base_prefix:
+            self.fail("Not running in a virtualenv")
 
-        self.assertTrue(path_contains(virtualenv_path, sys.executable))
-        self.assertTrue(path_contains(virtualenv_path, spam.__file__))
+        self.assertTrue(path_contains(sys.prefix, sys.executable))
+        self.assertTrue(path_contains(sys.prefix, spam.__file__))
 
     def test_uname(self):
         if platform.system() == "Windows":


### PR DESCRIPTION
I'm curious if this will allow us to get rid of the `__CIBW_VIRTUALENV_PATH__` environment variable we always set in the test virtualenv, with the only purpose of using it in our tests.

It's not brilliantly documented, but it seems a reasonable assumption and if anything changes in future `virtualenv` releases, this is much more likely to give false negative detections (and thus fail tests when they should not, rather than vice versa).

See #283