### PR TITLE
Use pathlib.Path

### DIFF
--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -3,10 +3,11 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 if __name__ == '__main__':
     # move cwd to the project root
-    os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    os.chdir(Path(__file__).resolve().parents[1])
 
     # run the unit tests
     subprocess.check_call([sys.executable, '-m', 'pytest', 'unit_test'])

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -21,6 +21,7 @@ from cibuildwheel.util import (
     BuildSelector,
     DependencyConstraints,
     Unbuffered,
+    resources_dir,
 )
 
 
@@ -165,7 +166,7 @@ def main() -> None:
     # This needs to be passed on to the docker container in linux.py
     os.environ['CIBUILDWHEEL'] = '1'
 
-    if not any((package_dir / name).exists()
+    if not any(package_dir.joinpath(name).exists()
                for name in ["setup.py", "setup.cfg", "pyproject.toml"]):
         print('cibuildwheel: Could not find setup.py, setup.cfg or pyproject.toml at root of package', file=sys.stderr)
         exit(2)
@@ -176,7 +177,7 @@ def main() -> None:
 
     manylinux_images: Optional[Dict[str, str]] = None
     if platform == 'linux':
-        pinned_docker_images_file = Path(__file__).parent / 'resources' / 'pinned_docker_images.cfg'
+        pinned_docker_images_file = resources_dir / 'pinned_docker_images.cfg'
         all_pinned_docker_images = ConfigParser()
         all_pinned_docker_images.read(pinned_docker_images_file)
         # all_pinned_docker_images looks like a dict of dicts, e.g.

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -166,7 +166,7 @@ def main() -> None:
     # This needs to be passed on to the docker container in linux.py
     os.environ['CIBUILDWHEEL'] = '1'
 
-    if not any(package_dir.joinpath(name).exists()
+    if not any((package_dir / name).exists()
                for name in ["setup.py", "setup.cfg", "pyproject.toml"]):
         print('cibuildwheel: Could not find setup.py, setup.cfg or pyproject.toml at root of package', file=sys.stderr)
         exit(2)

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import textwrap
 import uuid
+from pathlib import Path
 
 from typing import List, NamedTuple, Optional, Union
 
@@ -104,10 +105,12 @@ def build(options: BuildOptions) -> None:
         ('pp', 'manylinux_x86_64', options.manylinux_images['pypy_x86_64']),
     ]
 
-    if not os.path.realpath(options.package_dir).startswith(os.path.realpath('.')):
+    pwd = Path().resolve()
+    abs_package_dir = options.package_dir.resolve()
+    if pwd != abs_package_dir and pwd not in abs_package_dir.parents:
         raise Exception('package_dir must be inside the working directory')
 
-    container_package_dir = os.path.join('/project', os.path.relpath(options.package_dir, '.'))
+    container_package_dir = Path('/project') / abs_package_dir.relative_to(pwd)
 
     for implementation, platform_tag, docker_image in platforms:
         platform_configs = [c for c in python_configurations if c.identifier.startswith(implementation) and c.identifier.endswith(platform_tag)]
@@ -272,7 +275,7 @@ def build(options: BuildOptions) -> None:
             # copy the output back into the host
             call(['docker', 'cp',
                   container_name + ':/output/.',
-                  os.path.abspath(options.output_dir)])
+                  str(options.output_dir.resolve())])
         except subprocess.CalledProcessError as error:
             troubleshoot(options.package_dir, error)
             exit(1)
@@ -281,16 +284,11 @@ def build(options: BuildOptions) -> None:
             call(['docker', 'rm', '--force', '-v', container_name])
 
 
-def troubleshoot(package_dir: str, error: Exception) -> None:
+def troubleshoot(package_dir: Path, error: Exception) -> None:
     if (isinstance(error, subprocess.CalledProcessError) and 'exec' in error.cmd):
         # the bash script failed
         print('Checking for common errors...')
-        so_files = []
-        for root, dirs, files in os.walk(package_dir):
-            for name in files:
-                _, ext = os.path.splitext(name)
-                if ext == '.so':
-                    so_files.append(os.path.join(root, name))
+        so_files = list(package_dir.glob('**/*.so'))
 
         if so_files:
             print(textwrap.dedent('''
@@ -304,5 +302,5 @@ def troubleshoot(package_dir: str, error: Exception) -> None:
             '''))
 
             print('  Files detected:')
-            print('\n'.join(['    ' + f for f in so_files]))
+            print('\n'.join(['    ' + str(f) for f in so_files]))
             print('')

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import textwrap
 import uuid
-from pathlib import Path
+from pathlib import Path, PurePath
 
 from typing import List, NamedTuple, Optional, Union
 
@@ -105,12 +105,12 @@ def build(options: BuildOptions) -> None:
         ('pp', 'manylinux_x86_64', options.manylinux_images['pypy_x86_64']),
     ]
 
-    pwd = Path().resolve()
+    cwd = Path.cwd()
     abs_package_dir = options.package_dir.resolve()
-    if pwd != abs_package_dir and pwd not in abs_package_dir.parents:
+    if cwd != abs_package_dir and cwd not in abs_package_dir.parents:
         raise Exception('package_dir must be inside the working directory')
 
-    container_package_dir = Path('/project') / abs_package_dir.relative_to(pwd)
+    container_package_dir = PurePath('/project') / abs_package_dir.relative_to(cwd)
 
     for implementation, platform_tag, docker_image in platforms:
         platform_configs = [c for c in python_configurations if c.identifier.startswith(implementation) and c.identifier.endswith(platform_tag)]
@@ -302,5 +302,5 @@ def troubleshoot(package_dir: Path, error: Exception) -> None:
             '''))
 
             print('  Files detected:')
-            print('\n'.join(['    ' + str(f) for f in so_files]))
+            print('\n'.join([f'    {f}' for f in so_files]))
             print('')

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -4,7 +4,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from glob import glob
 from pathlib import Path
 
 from typing import Dict, List, Optional, NamedTuple, Union

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -24,7 +24,7 @@ def call(args: Union[str, List[str]], env: Optional[Dict[str, str]] = None, cwd:
     if shell:
         print(f'+ {args}')
     else:
-        print('+ ' + ' '.join(shlex.quote(str(a)) for a in args))
+        print('+ ' + ' '.join(shlex.quote(a) for a in args))
 
     return subprocess.check_call(args, env=env, cwd=cwd, shell=shell)
 
@@ -65,9 +65,9 @@ def make_symlinks(installation_bin_path: Path, python_executable: str, pip_execu
         shutil.rmtree(SYMLINKS_DIR)
     SYMLINKS_DIR.mkdir(parents=True)
 
-    (SYMLINKS_DIR / 'python').symlink_to(installation_bin_path / python_executable)
-    (SYMLINKS_DIR / 'python-config').symlink_to(installation_bin_path / (python_executable + '-config'))
-    (SYMLINKS_DIR / 'pip').symlink_to(installation_bin_path / pip_executable)
+    SYMLINKS_DIR.joinpath('python').symlink_to(installation_bin_path / python_executable)
+    SYMLINKS_DIR.joinpath('python-config').symlink_to(installation_bin_path / (python_executable + '-config'))
+    SYMLINKS_DIR.joinpath('pip').symlink_to(installation_bin_path / pip_executable)
 
 
 def install_cpython(version: str, url: str) -> Path:

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -249,7 +249,7 @@ def build(options: BuildOptions) -> None:
             test_command_prepared = prepare_command(
                 options.test_command,
                 project=Path('.').resolve(),
-                package=options.package_dir
+                package=options.package_dir.resolve()
             )
             call(test_command_prepared, cwd=os.environ['HOME'], env=virtualenv_env, shell=True)
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -207,7 +207,7 @@ def build(options: BuildOptions) -> None:
         repaired_wheel_dir.mkdir(parents=True)
         if built_wheel.name.endswith('none-any.whl') or not options.repair_command:
             # pure Python wheel or empty repair command
-            shutil.move(str(built_wheel), repaired_wheel_dir)
+            built_wheel.rename(repaired_wheel_dir / built_wheel.name)
         else:
             repair_command_prepared = prepare_command(options.repair_command, wheel=built_wheel, dest_dir=repaired_wheel_dir)
             call(repair_command_prepared, env=env, shell=True)
@@ -257,5 +257,4 @@ def build(options: BuildOptions) -> None:
             shutil.rmtree(venv_dir)
 
         # we're all done here; move it to output (overwrite existing)
-        dst = options.output_dir / repaired_wheel.name
-        shutil.move(str(repaired_wheel), dst)
+        repaired_wheel.replace(options.output_dir / repaired_wheel.name)

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -65,9 +65,9 @@ def make_symlinks(installation_bin_path: Path, python_executable: str, pip_execu
         shutil.rmtree(SYMLINKS_DIR)
     SYMLINKS_DIR.mkdir(parents=True)
 
-    SYMLINKS_DIR.joinpath('python').symlink_to(installation_bin_path / python_executable)
-    SYMLINKS_DIR.joinpath('python-config').symlink_to(installation_bin_path / (python_executable + '-config'))
-    SYMLINKS_DIR.joinpath('pip').symlink_to(installation_bin_path / pip_executable)
+    (SYMLINKS_DIR / 'python').symlink_to(installation_bin_path / python_executable)
+    (SYMLINKS_DIR / 'python-config').symlink_to(installation_bin_path / (python_executable + '-config'))
+    (SYMLINKS_DIR / 'pip').symlink_to(installation_bin_path / pip_executable)
 
 
 def install_cpython(version: str, url: str) -> Path:

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -90,7 +90,7 @@ class DependencyConstraints:
     @staticmethod
     def with_defaults() -> 'DependencyConstraints':
         return DependencyConstraints(
-            base_file_path=Path(__file__).parent / 'resources' / 'constraints.txt'
+            base_file_path=resources_dir / 'constraints.txt'
         )
 
     def get_for_python_version(self, version: str) -> Path:
@@ -99,8 +99,8 @@ class DependencyConstraints:
         # try to find a version-specific dependency file e.g. if
         # ./constraints.txt is the base, look for ./constraints-python27.txt
         specific_stem = self.base_file_path.stem + f'-python{version_parts[0]}{version_parts[1]}'
-        sepcific_name = specific_stem + self.base_file_path.suffix
-        specific_file_path = self.base_file_path.with_name(sepcific_name)
+        specific_name = specific_stem + self.base_file_path.suffix
+        specific_file_path = self.base_file_path.with_name(specific_name)
         if specific_file_path.exists():
             return specific_file_path
         else:

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -3,7 +3,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from glob import glob
 from pathlib import Path
 from zipfile import ZipFile
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -193,7 +193,7 @@ def build(options: BuildOptions) -> None:
         repaired_wheel_dir.mkdir(parents=True)
         if built_wheel.name.endswith('none-any.whl') or not options.repair_command:
             # pure Python wheel or empty repair command
-            shutil.move(str(built_wheel), repaired_wheel_dir)
+            built_wheel.rename(repaired_wheel_dir / built_wheel.name)
         else:
             repair_command_prepared = prepare_command(options.repair_command, wheel=built_wheel, dest_dir=repaired_wheel_dir)
             shell([repair_command_prepared], env=env)
@@ -247,7 +247,4 @@ def build(options: BuildOptions) -> None:
             shutil.rmtree(venv_dir)
 
         # we're all done here; move it to output (remove if already exists)
-        dst = options.output_dir / repaired_wheel.name
-        if dst.is_file():
-            dst.unlink()
-        shutil.move(str(repaired_wheel), dst)
+        repaired_wheel.replace(options.output_dir / repaired_wheel.name)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -96,7 +96,7 @@ def install_pypy(version: str, arch: str, url: str) -> Path:
         # Extract to the parent directory because the zip file still contains a directory
         extract_zip(pypy_zip, installation_path.parent)
         pypy_exe = 'pypy3.exe' if version[0] == '3' else 'pypy.exe'
-        (installation_path / pypy_exe).symlink_to(installation_path / 'python.exe')
+        (installation_path / 'python.exe').symlink_to(installation_path / pypy_exe)
     return installation_path
 
 

--- a/docs/mkdocs_include_markdown_plugin/mkdocs_include_markdown_plugin/plugin.py
+++ b/docs/mkdocs_include_markdown_plugin/mkdocs_include_markdown_plugin/plugin.py
@@ -1,7 +1,6 @@
 import cgi
-import io
-import os
 import re
+from pathlib import Path
 
 import mkdocs
 
@@ -41,13 +40,12 @@ class ImportMarkdownPlugin(mkdocs.plugins.BasePlugin):
         def found_include_tag(match):
             filename = match.group('filename')
 
-            file_path_abs = os.path.join(os.path.dirname(page_src_path), filename)
+            file_path_abs = Path(page_src_path).parent / filename
 
-            if not os.path.exists(file_path_abs):
+            if not file_path_abs.exists():
                 raise ValueError('file not found', filename)
 
-            with io.open(file_path_abs, encoding='utf8') as f:
-                text_to_include = f.read()
+            text_to_include = file_path_abs.read_text(encoding='utf8')
 
             # Allow good practice of having a final newline in the file
             if text_to_include.endswith('\n'):
@@ -60,13 +58,12 @@ class ImportMarkdownPlugin(mkdocs.plugins.BasePlugin):
             start = match.group('start')
             end = match.group('end')
 
-            file_path_abs = os.path.join(os.path.dirname(page_src_path), filename)
+            file_path_abs = Path(page_src_path).parent / filename
 
-            if not os.path.exists(file_path_abs):
+            if not file_path_abs.exists():
                 raise ValueError('file not found', filename)
 
-            with io.open(file_path_abs, encoding='utf8') as f:
-                text_to_include = f.read()
+            text_to_include = file_path_abs.read_text(encoding='utf8')
 
             if start:
                 _, _, text_to_include = text_to_include.partition(start)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
     from distutils.core import setup
 
 this_directory = Path(__file__).parent
-long_description = this_directory.joinpath('README.md').read_text(encoding='utf-8')
+long_description = (this_directory / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='cibuildwheel',

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
-import io
-import os
+from pathlib import Path
 
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
-this_directory = os.path.dirname(__file__)
-with io.open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
+this_directory = Path(__file__).parent
+long_description = this_directory.joinpath('README.md').read_text(encoding='utf-8')
 
 setup(
     name='cibuildwheel',

--- a/test/test_dependency_versions.py
+++ b/test/test_dependency_versions.py
@@ -1,4 +1,3 @@
-import os
 import re
 import pytest
 import textwrap
@@ -39,11 +38,9 @@ VERSION_REGEX = r'([\w-]+)==([^\s]+)'
 
 
 def get_versions_from_constraint_file(constraint_file):
-    with open(constraint_file, encoding='utf8') as f:
-        constraint_file_text = f.read()
+    constraint_file_text = constraint_file.read_text(encoding='utf8')
 
     versions = {}
-
     for package, version in re.findall(VERSION_REGEX, constraint_file_text):
         versions[package] = version
 
@@ -73,7 +70,7 @@ def test_pinned_versions(tmp_path, python_version):
         constraint_filename = 'constraints.txt'
         build_pattern = '[cp]p38-*'
 
-    constraint_file = os.path.join(cibuildwheel.util.resources_dir, constraint_filename)
+    constraint_file = cibuildwheel.util.resources_dir / constraint_filename
     constraint_versions = get_versions_from_constraint_file(constraint_file)
 
     for package in ['pip', 'setuptools', 'wheel', 'virtualenv']:

--- a/test/test_projects/base.py
+++ b/test/test_projects/base.py
@@ -1,5 +1,7 @@
-import os
+from pathlib import Path
+
 import jinja2
+
 from typing import Union, Dict, Any
 
 
@@ -21,12 +23,12 @@ class TestProject:
         self.files = {}
         self.template_context = {}
 
-    def generate(self, path: str):
+    def generate(self, path: Path):
         for filename, content in self.files.items():
-            file_path = os.path.join(path, filename)
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            file_path = path / filename
+            file_path.parent.mkdir(parents=True, exist_ok=True)
 
-            with open(file_path, 'w', encoding='utf8') as f:
+            with file_path.open('w', encoding='utf8') as f:
                 if isinstance(content, jinja2.Template):
                     content = content.render(self.template_context)
 

--- a/test/test_subdir_package.py
+++ b/test/test_subdir_package.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import jinja2
 
@@ -35,7 +35,7 @@ def test(capfd, tmp_path):
     project_dir = tmp_path / 'project'
     subdir_package_project.generate(project_dir)
 
-    package_dir = os.path.join('src', 'spam')
+    package_dir = Path('src', 'spam')
     # build the wheels
     actual_wheels = utils.cibuildwheel_run(project_dir, package_dir=package_dir, add_env={
         'CIBW_BEFORE_BUILD': 'python {project}/bin/before_build.py',

--- a/test/utils.py
+++ b/test/utils.py
@@ -10,9 +10,10 @@ import shutil
 import subprocess
 import sys
 from contextlib import contextmanager
+from pathlib import Path
 from tempfile import mkdtemp
 
-IS_WINDOWS_RUNNING_ON_AZURE = os.path.exists('C:\\hostedtoolcache')
+IS_WINDOWS_RUNNING_ON_AZURE = Path('C:\\hostedtoolcache').exists()
 IS_WINDOWS_RUNNING_ON_TRAVIS = os.environ.get('TRAVIS_OS_NAME') == 'windows'
 
 
@@ -66,7 +67,7 @@ def cibuildwheel_run(project_path, package_dir='.', env=None, add_env=None, outp
 
     with TemporaryDirectoryIfNone(output_dir) as _output_dir:
         subprocess.check_call(
-            [sys.executable, '-m', 'cibuildwheel', '--output-dir', str(_output_dir), package_dir],
+            [sys.executable, '-m', 'cibuildwheel', '--output-dir', str(_output_dir), str(package_dir)],
             env=env,
             cwd=project_path,
         )

--- a/unit_test/dependency_constraints_test.py
+++ b/unit_test/dependency_constraints_test.py
@@ -1,30 +1,16 @@
 from cibuildwheel.util import DependencyConstraints
-import os
+
+from pathlib import Path
 
 
 def test_defaults():
     dependency_constraints = DependencyConstraints.with_defaults()
 
-    project_root = os.path.dirname(os.path.dirname(__file__))
-    resources_dir = os.path.join(project_root, 'cibuildwheel', 'resources')
+    project_root = Path(__file__).parents[1]
+    resources_dir = project_root / 'cibuildwheel' / 'resources'
 
-    assert os.path.samefile(
-        dependency_constraints.base_file_path,
-        os.path.join(resources_dir, 'constraints.txt')
-    )
-    assert os.path.samefile(
-        dependency_constraints.get_for_python_version('3.8'),
-        os.path.join(resources_dir, 'constraints.txt')
-    )
-    assert os.path.samefile(
-        dependency_constraints.get_for_python_version('3.6'),
-        os.path.join(resources_dir, 'constraints-python36.txt')
-    )
-    assert os.path.samefile(
-        dependency_constraints.get_for_python_version('3.5'),
-        os.path.join(resources_dir, 'constraints-python35.txt')
-    )
-    assert os.path.samefile(
-        dependency_constraints.get_for_python_version('2.7'),
-        os.path.join(resources_dir, 'constraints-python27.txt')
-    )
+    assert dependency_constraints.base_file_path.samefile(resources_dir / 'constraints.txt')
+    assert dependency_constraints.get_for_python_version('3.8').samefile(resources_dir / 'constraints.txt')
+    assert dependency_constraints.get_for_python_version('3.6').samefile(resources_dir / 'constraints-python36.txt')
+    assert dependency_constraints.get_for_python_version('3.5').samefile(resources_dir / 'constraints-python35.txt')
+    assert dependency_constraints.get_for_python_version('2.7').samefile(resources_dir / 'constraints-python27.txt')

--- a/unit_test/main_tests/conftest.py
+++ b/unit_test/main_tests/conftest.py
@@ -31,11 +31,16 @@ def mock_protection(monkeypatch):
     def fail_on_call(*args, **kwargs):
         raise RuntimeError("This should never be called")
 
+    def ignore_call(*args, **kwargs):
+        pass
+
     monkeypatch.setattr(subprocess, 'Popen', fail_on_call)
     monkeypatch.setattr(util, 'download', fail_on_call)
     monkeypatch.setattr(windows, 'build', fail_on_call)
     monkeypatch.setattr(linux, 'build', fail_on_call)
     monkeypatch.setattr(macos, 'build', fail_on_call)
+
+    monkeypatch.setattr(Path, 'mkdir', ignore_call)
 
 
 @pytest.fixture(autouse=True)

--- a/unit_test/main_tests/conftest.py
+++ b/unit_test/main_tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -18,7 +19,7 @@ class ArgsInterceptor:
         self.kwargs = kwargs
 
 
-MOCK_PACKAGE_DIR = 'some_package_dir'
+MOCK_PACKAGE_DIR = Path('some_package_dir')
 
 
 @pytest.fixture(autouse=True)
@@ -43,16 +44,16 @@ def fake_package_dir(monkeypatch):
     '''
     Monkey-patch enough for the main() function to run
     '''
-    real_os_path_exists = os.path.exists
+    real_path_exists = Path.exists
 
-    def mock_os_path_exists(path):
-        if path == os.path.join(MOCK_PACKAGE_DIR, 'setup.py'):
+    def mock_path_exists(path):
+        if path == MOCK_PACKAGE_DIR / 'setup.py':
             return True
         else:
-            return real_os_path_exists(path)
+            return real_path_exists(path)
 
-    monkeypatch.setattr(os.path, 'exists', mock_os_path_exists)
-    monkeypatch.setattr(sys, 'argv', ['cibuildwheel', MOCK_PACKAGE_DIR])
+    monkeypatch.setattr(Path, 'exists', mock_path_exists)
+    monkeypatch.setattr(sys, 'argv', ['cibuildwheel', str(MOCK_PACKAGE_DIR)])
 
 
 @pytest.fixture(params=['linux', 'macos', 'windows'])

--- a/unit_test/main_tests/conftest.py
+++ b/unit_test/main_tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import sys
 from pathlib import Path

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -1,5 +1,6 @@
 import sys
 from fnmatch import fnmatch
+from pathlib import Path
 
 import pytest
 
@@ -12,9 +13,9 @@ from cibuildwheel.util import BuildSelector
 
 
 def test_output_dir(platform, intercepted_build_args, monkeypatch):
-    OUTPUT_DIR = 'some_output_dir'
+    OUTPUT_DIR = Path('some_output_dir')
 
-    monkeypatch.setenv('CIBW_OUTPUT_DIR', OUTPUT_DIR)
+    monkeypatch.setenv('CIBW_OUTPUT_DIR', str(OUTPUT_DIR))
 
     main()
 
@@ -24,14 +25,14 @@ def test_output_dir(platform, intercepted_build_args, monkeypatch):
 def test_output_dir_default(platform, intercepted_build_args, monkeypatch):
     main()
 
-    assert intercepted_build_args.args[0].output_dir == 'wheelhouse'
+    assert intercepted_build_args.args[0].output_dir == Path('wheelhouse')
 
 
 @pytest.mark.parametrize('also_set_environment', [False, True])
 def test_output_dir_argument(also_set_environment, platform, intercepted_build_args, monkeypatch):
-    OUTPUT_DIR = 'some_output_dir'
+    OUTPUT_DIR = Path('some_output_dir')
 
-    monkeypatch.setattr(sys, 'argv', sys.argv + ['--output-dir', OUTPUT_DIR])
+    monkeypatch.setattr(sys, 'argv', sys.argv + ['--output-dir', str(OUTPUT_DIR)])
     if also_set_environment:
         monkeypatch.setenv('CIBW_OUTPUT_DIR', 'not_this_output_dir')
 


### PR DESCRIPTION
As per #316, we can now play around with `pathlib.Path` and do it safely, because:
1. Python 3.6 and above support the [file system path protocol](https://www.python.org/dev/peps/pep-0519/), so we can pass `Path` objects to old `os.path` functions, etc.
2. We have typing (let's see how much errors mypy failed to catch)