### PR TITLE
Suppress warnings about pytest trying to collect TestProject

### DIFF
--- a/test/test_projects/base.py
+++ b/test/test_projects/base.py
@@ -14,6 +14,8 @@ class TestProject:
 
     Write out to the filesystem using `generate`.
     '''
+    __test__ = False  # Have pytest ignore this class on `from .test_projects import TestProject`
+
     files: FilesDict
     template_context: TemplateContext
 


### PR DESCRIPTION
Fixes #372

We (probably) need to use this `__test__ = False` attribute, because it's `from .test_projects import TestProject` that causes the warning. The `test_projects` subfolder is not the issue, since `base.py` does not have the `test_` prefix.

Alternatively, we could have a `new_base_project` function, similar to `new_c_project`?