### PR TITLE
Fix SSL error on Windows on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ jobs:
       language: shell
       before_install:
        - choco install python3 --version 3.6.8 --no-progress -y
+       # Update root certificates to fix SSL error; see http://www.chawn.com/RootCerts.htm
+       - powershell "md C:\temp\certs; CertUtil -generateSSTFromWU C:\temp\certs\RootStore.sst; Get-ChildItem -Path C:\\temp\certs\Rootstore.sst | Import-Certificate -CertStoreLocation Cert:\\LocalMachine\\Root\\ | out-null"
       env:
         - PYTHON=C:\\Python36\\python
 


### PR DESCRIPTION
Thanks to @mayeut, we have a solution for the failing Windows builds on Travis CI:  'ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'

See #378 for a discussion, but I'll merge this separately (once all builds are green), such that we can rebase the other PRs :-)