### PR TITLE
Update dependencies to get python 3.9 support on s390x

### DIFF
--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,22 +1,22 @@
 [x86_64]
-manylinux1 = quay.io/pypa/manylinux1_x86_64:2020-06-18-0eb93b9
-manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2020-06-16-1ee6b68
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2020-06-18-f5da004
+manylinux1 = quay.io/pypa/manylinux1_x86_64:2020-07-04-283458f
+manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2020-07-04-10a3c30
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2020-07-04-bb5f087
 
 [i686]
-manylinux1 = quay.io/pypa/manylinux1_i686:2020-06-18-0eb93b9
-manylinux2010 = quay.io/pypa/manylinux2010_i686:2020-06-16-1ee6b68
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2020-06-18-f5da004
+manylinux1 = quay.io/pypa/manylinux1_i686:2020-07-04-283458f
+manylinux2010 = quay.io/pypa/manylinux2010_i686:2020-07-04-10a3c30
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2020-07-04-bb5f087
 
 [pypy_x86_64]
-manylinux2010 = pypywheels/manylinux2010-pypy_x86_64:2020-04-25-eb2cdff
+manylinux2010 = pypywheels/manylinux2010-pypy_x86_64:2020-07-02-fd8c128
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2020-06-18-f5da004
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2020-07-04-bb5f087
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2020-06-18-f5da004
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2020-07-04-bb5f087
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2020-05-30-73c9395
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2020-07-04-bb5f087
 


### PR DESCRIPTION
Update dependencies to get python 3.9 support on s390x
Only updating manylinux images would be enough but this also tests other updates.