### PR TITLE
fix: Support environment markers in PEP 518 workaround

### DIFF
--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -172,8 +172,7 @@ def pep_518_cp35_workaround(package_dir: Path, env: Dict[str, str]) -> None:
             else []
         )
         if requirements:
-            escaped_requirements = [f'{s!r}' for s in requirements]
-            shell(['pip', 'install'] + escaped_requirements, env=env)
+            shell(['pip', 'install'] + requirements, env=env)
 
 
 def build(options: BuildOptions) -> None:

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Sequence, Union
 from zipfile import ZipFile
 import toml
-import shlex
 
 from .environment import ParsedEnvironment
 from .util import (BuildOptions, BuildSelector, download,
@@ -173,7 +172,7 @@ def pep_518_cp35_workaround(package_dir: Path, env: Dict[str, str]) -> None:
             else []
         )
         if requirements:
-            escaped_requirements = [shlex.quote(s) for s in requirements]
+            escaped_requirements = [f'{s!r}' for s in requirements]
             shell(['pip', 'install'] + escaped_requirements, env=env)
 
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Sequence, Union
 from zipfile import ZipFile
 import toml
+import shlex
 
 from .environment import ParsedEnvironment
 from .util import (BuildOptions, BuildSelector, download,
@@ -172,7 +173,8 @@ def pep_518_cp35_workaround(package_dir: Path, env: Dict[str, str]) -> None:
             else []
         )
         if requirements:
-            shell(['pip', 'install'] + requirements, env=env)
+            escaped_requirements = [shlex.quote(s) for s in requirements]
+            shell(['pip', 'install'] + escaped_requirements, env=env)
 
 
 def build(options: BuildOptions) -> None:

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -172,7 +172,8 @@ def pep_518_cp35_workaround(package_dir: Path, env: Dict[str, str]) -> None:
             else []
         )
         if requirements:
-            shell(['pip', 'install'] + requirements, env=env)
+            escaped_requirements = [f'"{s}"' for s in requirements]
+            shell(['pip', 'install'] + escaped_requirements, env=env)
 
 
 def build(options: BuildOptions) -> None:

--- a/test/test_pep518.py
+++ b/test/test_pep518.py
@@ -6,8 +6,12 @@ basic_project = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(
         """
         # Will fail if PEP 518 does work
+        import sys
         import requests
-        assert requests.__version__ == "2.23.0", "Requests found but wrong version ({0})".format(requests.__version__)
+        if sys.version_info < (3, 6, 0):
+            assert requests.__version__ == "2.22.0", "Requests found but wrong version ({0})".format(requests.__version__)
+        else:
+            assert requests.__version__ == "2.23.0", "Requests found but wrong version ({0})".format(requests.__version__)
 
         # Just making sure environment is still set
         import os
@@ -24,7 +28,8 @@ basic_project.files[
 requires = [
     "setuptools>=42",
     "wheel",
-    "requests==2.23.0"
+    "requests==2.22.0; python_version<'3.6'",
+    "requests==2.23.0; python_version>='3.6'"
 ]
 
 build-backend = "setuptools.build_meta"

--- a/test/test_pep518.py
+++ b/test/test_pep518.py
@@ -26,7 +26,7 @@ basic_project.files[
 ] = """
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools >= 42",
     "wheel",
     "requests==2.22.0; python_version<'3.6'",
     "requests==2.23.0; python_version>='3.6'"


### PR DESCRIPTION
The original version didn't handle environment markers, making the common idiom for supporting all NumPy versions: 

```ini
requires = [
    "numpy==1.13.3; python_version<='3.6'",
    "numpy==1.14.5; python_version=='3.7'",
    "numpy==1.17.3; python_version>='3.8'",
    ...
```

fail. Will fix #392.