### PR TITLE
Raise an error when cibuildwheel produces a non-platform wheel

### DIFF
--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 import urllib.request
 from fnmatch import fnmatch
 from pathlib import Path
@@ -126,3 +127,18 @@ class BuildOptions(NamedTuple):
 
 resources_dir = Path(__file__).resolve().parent / 'resources'
 get_pip_script = resources_dir / 'get-pip.py'
+
+
+class NonPlatformWheelError(Exception):
+    def __init__(self) -> None:
+        message = textwrap.dedent('''
+            cibuildwheel: Build failed because a pure Python wheel was generated.
+
+            If you intend to build a pure-Python wheel, you don't need cibuildwheel - use
+            `pip wheel -w DEST_DIR .` instead.
+
+            If you expected a platform wheel, check your project configuration, or run
+            cibuildwheel with CIBW_BUILD_VERBOSITY=1 to view build logs.
+        ''')
+
+        super().__init__(message)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -10,7 +10,7 @@ from zipfile import ZipFile
 import toml
 
 from .environment import ParsedEnvironment
-from .util import (BuildOptions, BuildSelector, download,
+from .util import (BuildOptions, BuildSelector, NonPlatformWheelError, download,
                    get_build_verbosity_extra_flags, get_pip_script,
                    prepare_command)
 
@@ -236,12 +236,16 @@ def build(options: BuildOptions) -> None:
         if repaired_wheel_dir.exists():
             shutil.rmtree(repaired_wheel_dir)
         repaired_wheel_dir.mkdir(parents=True)
-        if built_wheel.name.endswith('none-any.whl') or not options.repair_command:
-            # pure Python wheel or empty repair command
-            shutil.move(str(built_wheel), repaired_wheel_dir)
-        else:
+
+        if built_wheel.name.endswith('none-any.whl'):
+            raise NonPlatformWheelError()
+
+        if options.repair_command:
             repair_command_prepared = prepare_command(options.repair_command, wheel=built_wheel, dest_dir=repaired_wheel_dir)
             shell(repair_command_prepared, env=env)
+        else:
+            shutil.move(str(built_wheel), repaired_wheel_dir)
+
         repaired_wheel = next(repaired_wheel_dir.glob('*.whl'))
 
         if options.test_command:

--- a/test/test_pure_wheel.py
+++ b/test/test_pure_wheel.py
@@ -1,0 +1,36 @@
+import subprocess
+import pytest
+from test import test_projects
+from . import utils
+
+pure_python_project = test_projects.TestProject()
+pure_python_project.files['setup.py'] = '''
+from setuptools import Extension, setup
+
+setup(
+    name="spam",
+    py_modules=['spam'],
+    version="0.1.0",
+)
+'''
+
+pure_python_project.files['spam.py'] = '''
+def a_function():
+    pass
+'''
+
+
+def test(tmp_path, capfd):
+    # this test checks that if a pure wheel is generated, the build should
+    # fail.
+    project_dir = tmp_path / 'project'
+    pure_python_project.generate(project_dir)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        actual_wheels = utils.cibuildwheel_run(project_dir)
+        print('produced wheels:', actual_wheels)
+
+    captured = capfd.readouterr()
+    print('out', captured.out)
+    print('err', captured.err)
+    assert "Build failed because a pure Python wheel was generated" in captured.err


### PR DESCRIPTION
Fixes #255. Quick summary: non-platform wheels indicate a problem, normally because an optional extension has failed to build, or because a user misunderstands what cibuildwheel is for. This should help catch those cases.