### PR TITLE
Add project_urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ setup(
     author="Joe Rickerby",
     author_email='joerick@mac.com',
     url='https://github.com/joerick/cibuildwheel',
+    project_urls={
+        'Changelog': 'https://github.com/joerick/cibuildwheel#changelog',
+        'Documentation': 'https://cibuildwheel.readthedocs.io/',
+    },
     packages=['cibuildwheel', ],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
These links make it easier to jump from PyPI to the respective page.