### PR TITLE
Fix TravisCI deploy example link and TravisCI config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ jobs:
       before_install:
         - choco install python --version 3.8.0
         - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+        # make sure it's on PATH as 'python3'
+        - ln -s /c/Python38/python.exe /c/Python38/python3.exe
 
 env:
   global:
@@ -143,7 +145,7 @@ Here are some repos that use cibuildwheel.
 - [etebase-py](https://github.com/etesync/etebase-py) - Python bindings to a Rust library using `setuptools-rust`, and `sccache` for improved speed, built on Travis CI.
 
 > Add your repo here! Send a PR.
-> 
+>
 > <sup>I'd like to include notes here to indicate why an example might be interesting to cibuildwheel users - the styles/technologies/techniques used in each. Please include that in future additions!</sup>
 
 Legal note

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -48,7 +48,7 @@ Commit this file, enable building of your repo on Travis CI, and push.
 
 Then setup a deployment method by following the [Travis CI deployment docs](https://docs.travis-ci.com/user/deployment/), or see [Delivering to PyPI](deliver-to-pypi.md). For more info on `.travis.yml`, check out the [docs](https://docs.travis-ci.com/).
 
-[`examples/travis-deploy.yml`](https://github.com/joerick/cibuildwheel/blob/master/examples/travis-deploy.yml) extends this minimal example with a demonstration of how to automatically upload the built wheels to PyPI.
+[`examples/travis-ci-deploy.yml`](https://github.com/joerick/cibuildwheel/blob/master/examples/travis-ci-deploy.yml) extends this minimal example with a demonstration of how to automatically upload the built wheels to PyPI.
 
 # CircleCI [linux/mac] {: #circleci}
 


### PR DESCRIPTION
- TravisCI deploy example link of docs was pointing to inexistent file.
- TravisCI config example on README didn't include the python3 link in PATH for Windows build.