### PR TITLE
Make sure that wheels are replaced by repaireds moving to output dir

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -272,7 +272,4 @@ def build(options: BuildOptions) -> None:
             shutil.rmtree(venv_dir)
 
         # we're all done here; move it to output (overwrite existing)
-        repaired_wheel_output_path = os.path.join(options.output_dir, str(repaired_wheel))
-        if os.path.exists(repaired_wheel_output_path):
-            os.remove(repaired_wheel_output_path)
-        shutil.move(str(repaired_wheel), options.output_dir)
+        os.replace(str(repaired_wheel), os.path.join(options.output_dir, str(repaired_wheel)))

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -272,4 +272,7 @@ def build(options: BuildOptions) -> None:
             shutil.rmtree(venv_dir)
 
         # we're all done here; move it to output (overwrite existing)
+        repaired_wheel_output_path = os.path.join(options.output_dir, str(repaired_wheel))
+        if os.path.exists(repaired_wheel_output_path):
+            os.remove(repaired_wheel_output_path)
         shutil.move(str(repaired_wheel), options.output_dir)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -304,4 +304,7 @@ def build(options: BuildOptions) -> None:
             shutil.rmtree(venv_dir)
 
         # we're all done here; move it to output (remove if already exists)
+        repaired_wheel_output_path = os.path.join(options.output_dir, str(repaired_wheel))
+        if os.path.exists(repaired_wheel_output_path):
+            os.remove(repaired_wheel_output_path)
         shutil.move(str(repaired_wheel), options.output_dir)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -304,7 +304,4 @@ def build(options: BuildOptions) -> None:
             shutil.rmtree(venv_dir)
 
         # we're all done here; move it to output (remove if already exists)
-        repaired_wheel_output_path = os.path.join(options.output_dir, str(repaired_wheel))
-        if os.path.exists(repaired_wheel_output_path):
-            os.remove(repaired_wheel_output_path)
-        shutil.move(str(repaired_wheel), options.output_dir)
+        os.replace(str(repaired_wheel), os.path.join(options.output_dir, str(repaired_wheel)))


### PR DESCRIPTION
I'm experiencing this issue building wheels in MacOS:

```
Traceback (most recent call last):
  File "/usr/local/bin/cibuildwheel", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/cibuildwheel/__main__.py", line 238, in main
    cibuildwheel.macos.build(build_options)
  File "/usr/local/lib/python3.7/site-packages/cibuildwheel/macos.py", line 275, in build
    shutil.move(str(repaired_wheel), options.output_dir)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/shutil.py", line 564, in move
    raise Error("Destination path '%s' already exists" % real_dst)
shutil.Error: Destination path 'wheelhouse/polf-0.0.7-cp36-cp36m-macosx_10_9_x86_64.whl' already exists
```

Seeing [`shutil.move` docs](https://docs.python.org/3/library/shutil.html#shutil.move) I've found that says "If the destination already exists but is not a directory, it may be overwritten depending on os.rename() semantics."

So  `shutil.move` does not necessarily overwrite files when moving and these files must be removed if exists previously.