### PR TITLE
chore: update to 3.9.0 final

### DIFF
--- a/bin/update_dependencies.py
+++ b/bin/update_dependencies.py
@@ -19,7 +19,7 @@ subprocess.check_call([
     '--upgrade',
     'cibuildwheel/resources/constraints.in',
 ])
-for python_version in ['27', '35', '36']:
+for python_version in ['27', '35', '36', '37']:
     subprocess.check_call([
         f'./env{python_version}/bin/pip-compile',
         '--allow-unsafe',

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -38,7 +38,7 @@ def get_python_configurations(build_selector: BuildSelector) -> List[PythonConfi
         PythonConfiguration(version='3.6', identifier='cp36-macosx_x86_64', url='https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg'),
         PythonConfiguration(version='3.7', identifier='cp37-macosx_x86_64', url='https://www.python.org/ftp/python/3.7.8/python-3.7.8-macosx10.9.pkg'),
         PythonConfiguration(version='3.8', identifier='cp38-macosx_x86_64', url='https://www.python.org/ftp/python/3.8.4/python-3.8.4-macosx10.9.pkg'),
-        PythonConfiguration(version='3.9', identifier='cp39-macosx_x86_64', url='https://www.python.org/ftp/python/3.9.0/python-3.9.0rc1-macosx10.9.pkg'),
+        PythonConfiguration(version='3.9', identifier='cp39-macosx_x86_64', url='https://www.python.org/ftp/python/3.9.0/python-3.9.0-macosx10.9.pkg'),
         # PyPy
         PythonConfiguration(version='2.7', identifier='pp27-macosx_x86_64', url='https://downloads.python.org/pypy/pypy2.7-v7.3.2-osx64.tar.bz2'),
         PythonConfiguration(version='3.6', identifier='pp36-macosx_x86_64', url='https://downloads.python.org/pypy/pypy3.6-v7.3.2-osx64.tar.bz2'),

--- a/cibuildwheel/resources/constraints-python27.txt
+++ b/cibuildwheel/resources/constraints-python27.txt
@@ -10,17 +10,17 @@ contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources
 delocate==0.8.2           # via -r cibuildwheel/resources/constraints.in
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via virtualenv
-importlib-metadata==1.7.0  # via virtualenv
+importlib-metadata==2.0.0  # via virtualenv
 importlib-resources==3.0.0  # via virtualenv
 pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 scandir==1.10.0           # via pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
 six==1.15.0               # via pathlib2, virtualenv
 typing==3.7.4.3           # via importlib-resources
-virtualenv==20.0.31       # via -r cibuildwheel/resources/constraints.in
+virtualenv==20.0.33       # via -r cibuildwheel/resources/constraints.in
 wheel==0.35.1             # via -r cibuildwheel/resources/constraints.in, delocate
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.2.2               # via -r cibuildwheel/resources/constraints.in
+pip==20.2.3               # via -r cibuildwheel/resources/constraints.in
 setuptools==44.1.1        # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/constraints-python35.txt
+++ b/cibuildwheel/resources/constraints-python35.txt
@@ -8,13 +8,13 @@ appdirs==1.4.4            # via virtualenv
 delocate==0.8.2           # via -r cibuildwheel/resources/constraints.in
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via virtualenv
-importlib-metadata==1.7.0  # via virtualenv
+importlib-metadata==2.0.0  # via virtualenv
 importlib-resources==3.0.0  # via virtualenv
 six==1.15.0               # via virtualenv
-virtualenv==20.0.31       # via -r cibuildwheel/resources/constraints.in
+virtualenv==20.0.33       # via -r cibuildwheel/resources/constraints.in
 wheel==0.35.1             # via -r cibuildwheel/resources/constraints.in, delocate
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.2.2               # via -r cibuildwheel/resources/constraints.in
+pip==20.2.3               # via -r cibuildwheel/resources/constraints.in
 setuptools==50.3.0        # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/constraints-python36.txt
+++ b/cibuildwheel/resources/constraints-python36.txt
@@ -8,13 +8,13 @@ appdirs==1.4.4            # via virtualenv
 delocate==0.8.2           # via -r cibuildwheel/resources/constraints.in
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via virtualenv
-importlib-metadata==1.7.0  # via virtualenv
+importlib-metadata==2.0.0  # via virtualenv
 importlib-resources==3.0.0  # via virtualenv
 six==1.15.0               # via virtualenv
-virtualenv==20.0.31       # via -r cibuildwheel/resources/constraints.in
+virtualenv==20.0.33       # via -r cibuildwheel/resources/constraints.in
 wheel==0.35.1             # via -r cibuildwheel/resources/constraints.in, delocate
-zipp==3.1.0               # via importlib-metadata, importlib-resources
+zipp==3.3.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.2.2               # via -r cibuildwheel/resources/constraints.in
+pip==20.2.3               # via -r cibuildwheel/resources/constraints.in
 setuptools==50.3.0        # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/constraints-python37.txt
+++ b/cibuildwheel/resources/constraints-python37.txt
@@ -8,9 +8,11 @@ appdirs==1.4.4            # via virtualenv
 delocate==0.8.2           # via -r cibuildwheel/resources/constraints.in
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via virtualenv
+importlib-metadata==2.0.0  # via virtualenv
 six==1.15.0               # via virtualenv
 virtualenv==20.0.33       # via -r cibuildwheel/resources/constraints.in
 wheel==0.35.1             # via -r cibuildwheel/resources/constraints.in, delocate
+zipp==3.3.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.2.3               # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,22 +1,22 @@
 [x86_64]
-manylinux1 = quay.io/pypa/manylinux1_x86_64:2020-09-26-9f151ab
-manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2020-09-26-58cbbcd
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2020-09-26-7f7a14f
+manylinux1 = quay.io/pypa/manylinux1_x86_64:2020-10-06-c4a4a7c
+manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2020-10-06-786a931
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2020-10-06-b2ca7a1
 
 [i686]
-manylinux1 = quay.io/pypa/manylinux1_i686:2020-09-26-9f151ab
-manylinux2010 = quay.io/pypa/manylinux2010_i686:2020-09-26-58cbbcd
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2020-09-26-7f7a14f
+manylinux1 = quay.io/pypa/manylinux1_i686:2020-10-06-c4a4a7c
+manylinux2010 = quay.io/pypa/manylinux2010_i686:2020-10-06-786a931
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2020-10-06-b2ca7a1
 
 [pypy_x86_64]
 manylinux2010 = pypywheels/manylinux2010-pypy_x86_64:2020-09-26-8f210b5
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2020-09-26-7f7a14f
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2020-10-05-2f3b046
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2020-09-26-7f7a14f
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2020-10-06-b2ca7a1
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2020-09-26-7f7a14f
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2020-10-06-b2ca7a1
 

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -12,11 +12,10 @@ manylinux2014 = quay.io/pypa/manylinux2014_i686:2020-10-06-b2ca7a1
 manylinux2010 = pypywheels/manylinux2010-pypy_x86_64:2020-09-26-8f210b5
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2020-10-05-2f3b046
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2020-10-06-b2ca7a1
 
 [ppc64le]
 manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2020-10-06-b2ca7a1
 
 [s390x]
 manylinux2014 = quay.io/pypa/manylinux2014_s390x:2020-10-06-b2ca7a1
-

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -58,8 +58,8 @@ def get_python_configurations(build_selector: BuildSelector) -> List[PythonConfi
         PythonConfiguration(version='3.7.8', arch='64', identifier='cp37-win_amd64', url=None),
         PythonConfiguration(version='3.8.4', arch='32', identifier='cp38-win32', url=None),
         PythonConfiguration(version='3.8.4', arch='64', identifier='cp38-win_amd64', url=None),
-        PythonConfiguration(version='3.9.0-rc1', arch='32', identifier='cp39-win32', url=None),
-        PythonConfiguration(version='3.9.0-rc1', arch='64', identifier='cp39-win_amd64', url=None),
+        PythonConfiguration(version='3.9.0', arch='32', identifier='cp39-win32', url=None),
+        PythonConfiguration(version='3.9.0', arch='64', identifier='cp39-win_amd64', url=None),
         # PyPy
         PythonConfiguration(version='2.7', arch='32', identifier='pp27-win32', url='https://downloads.python.org/pypy/pypy2.7-v7.3.2-win32.zip'),
         PythonConfiguration(version='3.6', arch='32', identifier='pp36-win32', url='https://downloads.python.org/pypy/pypy3.6-v7.3.2-win32.zip'),

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,29 +38,69 @@ cibuildwheel's _minimal_ example configs can be tested on a simple project on ci
 
 To test minimal configs, make sure you have a clean git repo, then run the script:
 
-    bin/run_example_ci_configs.py
+```bash
+bin/run_example_ci_configs.py
+```
 
 The script will create an isolated 'orphan' commit containing all the minimal config CI files, and a simple C extension project, and push that to a branch on the `origin` repo. The project's CI is already set up to run on branch push, so will begin testing.
 
 The script then outputs a Markdown table that can be copy/pasted into a PR to monitor and record the test.
 
+## Preparing environments
+
+The dependency update script in the next section requires multiple python versions installed. One way to do this is to use `pyenv`:
+
+```bash
+pyenv install 2.7.18
+pyenv install 3.5.9
+pyenv install 3.6.11
+pyenv install 3.7.8
+# Optionally add 3.8 and make it the local version;
+# otherwise assuming 3.8+ already is your current python version
+```
+
+Then, you need to make the required virtual environments:
+
+```bash
+$(pyenv prefix 2.7.18)/bin/python -m pip install virtualenv
+$(pyenv prefix 2.7.18)/bin/python -m virtualenv env27
+$(pyenv prefix 3.5.9)/bin/python -m venv env35
+$(pyenv prefix 3.6.11)/bin/python -m venv env36
+$(pyenv prefix 3.7.8)/bin/python -m venv env37
+```
+
+<!-- Note for fish users: use zsh/bash for these lines for now, there's not a nice one-line fish replacement -->
+
+And, you need to install the requirements into each environment:
+
+```bash
+for f in env*/bin/pip; do $f install pip-tools; done
+```
+
+
 ## Making a release
 
 Before making a release, ensure pinned dependencies are up-to-date. Run the script:
 
-    bin/make_dependency_update_pr.py
+```bash
+bin/make_dependency_update_pr.py
+```
 
 If updates are needed, this will push a PR with those updates for the CI to test. Once green, merge this PR.
 
 Then, increment the project version number using:
 
-    bin/bump_version.py
+```bash
+bin/bump_version.py
+```
 
 You'll be prompted to enter the new version number. Update the changelog when prompted. The script will create a 'bump version' commit and version tag.
 
 Finally, cut the release and upload to PyPI/Github.
 
-    rm -rf dist
-    python setup.py sdist bdist_wheel
-    twine upload dist/*
-    git push && git push --tags
+```bash
+rm -rf dist
+python setup.py sdist bdist_wheel
+twine upload dist/*
+git push && git push --tags
+```

--- a/test/test_dependency_versions.py
+++ b/test/test_dependency_versions.py
@@ -66,6 +66,9 @@ def test_pinned_versions(tmp_path, python_version):
     elif python_version == '3.6':
         constraint_filename = 'constraints-python36.txt'
         build_pattern = '[cp]p36-*'
+    elif python_version == '3.7':
+        constraint_filename = 'constraints-python37.txt'
+        build_pattern = '[cp]p37-*'
     else:
         constraint_filename = 'constraints.txt'
         build_pattern = '[cp]p38-*'


### PR DESCRIPTION
Python 3.9.0 was released yesterday. Nuget was fast, though Manylinux finally updated 5 hours ago ~~(do we pin a docker image? If not, this should just work?)~~. Bumping macOS and Windows to 3.9.0. The other requirements should possibly be bumped before a release is made with 3.9.0 final, I think (@joerick?).

Edit: Oops, they are pinned, just found that. Will update.