### PR TITLE
Add Python 3.9 to build identifiers table in docs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -86,6 +86,7 @@ When setting the options, you can use shell-style globbing syntax (as per [`fnma
 | Python 3.6      | cp36-macosx_x86_64  | cp36-manylinux_x86_64  | cp36-manylinux_i686  | cp36-win_amd64  | cp36-win32     | cp36-manylinux_aarch64 | cp36-manylinux_ppc64le | cp36-manylinux_s390x |
 | Python 3.7      | cp37-macosx_x86_64  | cp37-manylinux_x86_64  | cp37-manylinux_i686  | cp37-win_amd64  | cp37-win32     | cp37-manylinux_aarch64 | cp37-manylinux_ppc64le | cp37-manylinux_s390x |
 | Python 3.8      | cp38-macosx_x86_64  | cp38-manylinux_x86_64  | cp38-manylinux_i686  | cp38-win_amd64  | cp38-win32     | cp38-manylinux_aarch64 | cp38-manylinux_ppc64le | cp38-manylinux_s390x |
+| Python 3.9      | cp39-macosx_x86_64  | cp39-manylinux_x86_64  | cp39-manylinux_i686  | cp39-win_amd64  | cp39-win32     | cp39-manylinux_aarch64 | cp39-manylinux_ppc64le | cp39-manylinux_s390x |
 | PyPy 2.7 v7.3.2 | pp27-macosx_x86_64  | pp27-manylinux_x86_64  |                      |                 | pp27-win32     |                        |                        |                      |
 | PyPy 3.6 v7.3.2 | pp36-macosx_x86_64  | pp36-manylinux_x86_64  |                      |                 | pp36-win32     |                        |                        |                      |
 | PyPy 3.7 (alpha) v7.3.2 | pp37-macosx_x86_64  | pp37-manylinux_x86_64  |                      |                 | pp37-win32     |                        |                        |                      |


### PR DESCRIPTION
Just noticed this was missing from the docs, have added it :)