### PR TITLE
Add str representation to DependencyConstraints

### DIFF
--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -107,6 +107,9 @@ class DependencyConstraints:
         else:
             return self.base_file_path
 
+    def __str__(self):
+        return f"File '{self.base_file_path}'"
+
 
 class BuildOptions(NamedTuple):
     package_dir: Path


### PR DESCRIPTION
I found that current preamble contains:

```
  dependency_constraints: <cibuildwheel.util.DependencyConstraints object at 0x10d4ca640>
```

So I add `__str__` method to DependencyConstraints class.