### PR TITLE
Update openssl patch from 1.0.2u to 1.1.1h on macOS

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -82,7 +82,7 @@ def install_cpython(version: str, url: str) -> Path:
         call(['sudo', 'installer', '-pkg', '/tmp/Python.pkg', '-target', '/'])
         # patch open ssl
         if version == '3.5':
-            open_ssl_patch_url = f'https://github.com/mayeut/patch-macos-python-openssl/releases/download/v1.0.2u/patch-macos-python-{version}-openssl-v1.0.2u.tar.gz'
+            open_ssl_patch_url = f'https://github.com/mayeut/patch-macos-python-openssl/releases/download/v1.1.1h/patch-macos-python-{version}-openssl-v1.1.1h.tar.gz'
             download(open_ssl_patch_url, Path('/tmp/python-patch.tar.gz'))
             call(['sudo', 'tar', '-C', f'/Library/Frameworks/Python.framework/Versions/{version}/', '-xmf', '/tmp/python-patch.tar.gz'])
 

--- a/cibuildwheel/resources/install_certifi.py
+++ b/cibuildwheel/resources/install_certifi.py
@@ -30,8 +30,6 @@ def main():
 
     import certifi
     # change working directory to the default SSL directory
-    if sys.version_info[0:2] == (3, 5):
-        os.makedirs(openssl_dir, exist_ok=True, mode=0o775)
     os.chdir(openssl_dir)
     relpath_to_certifi_cafile = os.path.relpath(certifi.where())
 


### PR DESCRIPTION
- Update openssl patch from 1.0.2u to 1.1.1h on macOS
- Remove python 3.5 workaround in install_certifi.py (now included in patch)

This will probably be the last update now that python 3.5 has reached End-Of-Life.