### PR TITLE
Use certifi provided certificates when downloading files

### DIFF
--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -1,6 +1,8 @@
 import os
 import textwrap
+import certifi
 import urllib.request
+import ssl
 from fnmatch import fnmatch
 from pathlib import Path
 from time import sleep
@@ -66,10 +68,12 @@ def download(url: str, dest: Path) -> None:
     if not dest_dir.exists():
         dest_dir.mkdir(parents=True)
 
+    cafile = os.environ.get('SSL_CERT_FILE', certifi.where())
+    context = ssl.create_default_context(cafile=cafile)
     repeat_num = 3
     for i in range(repeat_num):
         try:
-            response = urllib.request.urlopen(url)
+            response = urllib.request.urlopen(url, context=context)
         except Exception:
             if i == repeat_num - 1:
                 raise

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -68,6 +68,8 @@ def download(url: str, dest: Path) -> None:
     if not dest_dir.exists():
         dest_dir.mkdir(parents=True)
 
+    # we've had issues when relying on the host OS' CA certificates on Windows,
+    # so we use certifi (this sounds odd but requests also does this by default)
     cafile = os.environ.get('SSL_CERT_FILE', certifi.where())
     context = ssl.create_default_context(cafile=cafile)
     repeat_num = 3

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = (this_directory / 'README.md').read_text(encoding='utf-8')
 setup(
     name='cibuildwheel',
     version='1.6.3',
-    install_requires=['bashlex!=0.13', 'toml'],
+    install_requires=['bashlex!=0.13', 'toml', 'certifi'],
     description="Build Python wheels on CI with minimal configuration.",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/unit_test/download_test.py
+++ b/unit_test/download_test.py
@@ -5,20 +5,20 @@ import ssl
 from cibuildwheel.util import download
 
 
-DONWLOAD_URL = 'https://raw.githubusercontent.com/joerick/cibuildwheel/v1.6.3/requirements-dev.txt'
+DOWNLOAD_URL = 'https://raw.githubusercontent.com/joerick/cibuildwheel/v1.6.3/requirements-dev.txt'
 
 
 def test_download(monkeypatch, tmp_path):
     monkeypatch.delenv('SSL_CERT_FILE', raising=False)
     dest = tmp_path / 'file.txt'
-    download(DONWLOAD_URL, dest)
+    download(DOWNLOAD_URL, dest)
     assert len(dest.read_bytes()) == 134
 
 
 def test_download_good_ssl_cert_file(monkeypatch, tmp_path):
     monkeypatch.setenv('SSL_CERT_FILE', certifi.where())
     dest = tmp_path / 'file.txt'
-    download(DONWLOAD_URL, dest)
+    download(DOWNLOAD_URL, dest)
     assert len(dest.read_bytes()) == 134
 
 
@@ -28,4 +28,4 @@ def test_download_bad_ssl_cert_file(monkeypatch, tmp_path):
     monkeypatch.setenv('SSL_CERT_FILE', str(bad_cafile))
     dest = tmp_path / 'file.txt'
     with pytest.raises(ssl.SSLError):
-        download(DONWLOAD_URL, dest)
+        download(DOWNLOAD_URL, dest)

--- a/unit_test/download_test.py
+++ b/unit_test/download_test.py
@@ -1,0 +1,31 @@
+import certifi
+import pytest
+import ssl
+
+from cibuildwheel.util import download
+
+
+DONWLOAD_URL = 'https://raw.githubusercontent.com/joerick/cibuildwheel/v1.6.3/requirements-dev.txt'
+
+
+def test_download(monkeypatch, tmp_path):
+    monkeypatch.delenv('SSL_CERT_FILE', raising=False)
+    dest = tmp_path / 'file.txt'
+    download(DONWLOAD_URL, dest)
+    assert len(dest.read_bytes()) == 134
+
+
+def test_download_good_ssl_cert_file(monkeypatch, tmp_path):
+    monkeypatch.setenv('SSL_CERT_FILE', certifi.where())
+    dest = tmp_path / 'file.txt'
+    download(DONWLOAD_URL, dest)
+    assert len(dest.read_bytes()) == 134
+
+
+def test_download_bad_ssl_cert_file(monkeypatch, tmp_path):
+    bad_cafile = tmp_path / 'ca.pem'
+    bad_cafile.write_text('bad certificates')
+    monkeypatch.setenv('SSL_CERT_FILE', str(bad_cafile))
+    dest = tmp_path / 'file.txt'
+    with pytest.raises(ssl.SSLError):
+        download(DONWLOAD_URL, dest)


### PR DESCRIPTION
As [proposed](https://github.com/joerick/cibuildwheel/issues/452#issuecomment-718817456) by @jcrist, use `certifi` certificates when downloading files from host using the `download` function in `cibuildwheel/util.py`.
This behavior can be overridden using the `SSL_CERT_FILE ` environment variable.

fix #452