### PR TITLE
Use set -o errexit in the Azure example

### DIFF
--- a/examples/azure-pipelines-minimal.yml
+++ b/examples/azure-pipelines-minimal.yml
@@ -7,8 +7,9 @@ jobs:
         set -o errexit
         python3 -m pip install --upgrade pip
         pip3 install cibuildwheel==1.6.4
-    - displayName: Build wheels
-      bash: cibuildwheel --output-dir wheelhouse .
+      displayName: Install dependencies
+    - bash: cibuildwheel --output-dir wheelhouse .
+      displayName: Build wheels
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}
 
@@ -16,13 +17,13 @@ jobs:
   pool: {vmImage: 'macOS-10.15'}
   steps:
     - task: UsePythonVersion@0
-    - displayName: Install dependencies
-      bash: |
+    - bash: |
         set -o errexit
         python3 -m pip install --upgrade pip
         python3 -m pip install cibuildwheel==1.6.4
-    - displayName: Build wheels
-      bash: cibuildwheel --output-dir wheelhouse .
+      displayName: Install dependencies
+    - bash: cibuildwheel --output-dir wheelhouse .
+      displayName: Build wheels
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: wheelhouse}
 
@@ -36,7 +37,8 @@ jobs:
         set -o errexit
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.6.4
-    - displayName: Build wheels
-      bash: cibuildwheel --output-dir wheelhouse .
+      displayName: Install dependencies
+    - bash: cibuildwheel --output-dir wheelhouse .
+      displayName: Build wheels
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}

--- a/examples/azure-pipelines-minimal.yml
+++ b/examples/azure-pipelines-minimal.yml
@@ -4,6 +4,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
     - bash: |
+        set -o errexit
         python3 -m pip install --upgrade pip
         pip3 install cibuildwheel==1.6.4
         cibuildwheel --output-dir wheelhouse .
@@ -15,6 +16,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
     - bash: |
+        set -o errexit
         python3 -m pip install --upgrade pip
         pip3 install cibuildwheel==1.6.4
         cibuildwheel --output-dir wheelhouse .
@@ -28,6 +30,7 @@ jobs:
     - script: choco install vcpython27 -f -y
       displayName: Install Visual C++ for Python 2.7
     - bash: |
+        set -o errexit
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.6.4
         cibuildwheel --output-dir wheelhouse .

--- a/examples/azure-pipelines-minimal.yml
+++ b/examples/azure-pipelines-minimal.yml
@@ -7,7 +7,8 @@ jobs:
         set -o errexit
         python3 -m pip install --upgrade pip
         pip3 install cibuildwheel==1.6.4
-        cibuildwheel --output-dir wheelhouse .
+    - displayName: Build wheels
+      bash: cibuildwheel --output-dir wheelhouse .
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}
 
@@ -15,13 +16,15 @@ jobs:
   pool: {vmImage: 'macOS-10.15'}
   steps:
     - task: UsePythonVersion@0
-    - bash: |
+    - displayName: Install dependencies
+      bash: |
         set -o errexit
         python3 -m pip install --upgrade pip
-        pip3 install cibuildwheel==1.6.4
-        cibuildwheel --output-dir wheelhouse .
+        python3 -m pip install cibuildwheel==1.6.4
+    - displayName: Build wheels
+      bash: cibuildwheel --output-dir wheelhouse .
     - task: PublishBuildArtifacts@1
-      inputs: {pathtoPublish: 'wheelhouse'}
+      inputs: {pathtoPublish: wheelhouse}
 
 - job: windows
   pool: {vmImage: 'vs2017-win2016'}
@@ -33,6 +36,7 @@ jobs:
         set -o errexit
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.6.4
-        cibuildwheel --output-dir wheelhouse .
+    - displayName: Build wheels
+      bash: cibuildwheel --output-dir wheelhouse .
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}


### PR DESCRIPTION
As mentioned in #205, Azure Pipelines continues to run a bash script even if a subcommand fails. To be fair, this is the default bash behaviour, but it can lead to nasty surprises (like build that report they've passed even though tests have failed). This PR adds `set -o errexit` to our examples.

Worth noting, another option would be to split these into separate actions, like

```yaml
- job: macos
  pool: {vmImage: 'macOS-10.15'}
  steps:
    - task: UsePythonVersion@0
    - bash: python3 -m pip install --upgrade pip
    - bash: pip3 install cibuildwheel==1.6.4
    - bash: cibuildwheel --output-dir wheelhouse .
    - task: PublishBuildArtifacts@1
      inputs: {pathtoPublish: 'wheelhouse'}
```

Any preference between the above and this PR?

