### PR TITLE
Improve Github triggers to prevent multiple runs on origin branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,14 @@
 name: Test
 
 on:
-  push: {}
+  push:
+    branches:
+      - master
   pull_request:
     paths-ignore:
       - 'docs/**'
-    branches:
-      # PRs from branches on the origin repo get a build from the 'push'
-      # trigger. So the pull_request trigger is limited to fork branches
-      - '**:**'
+  workflow_dispatch:
+    # allow manual runs on branches without a PR
 
 jobs:
   pre-commit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+    branches:
+      # PRs from branches on the origin repo get a build from the 'push'
+      # trigger. So the pull_request trigger is limited to fork branches
+      - '**:**'
 
 jobs:
   pre-commit:
@@ -16,9 +20,6 @@ jobs:
     - uses: pre-commit/action@v2.0.0
 
   test:
-    # skip branch builds on joerick/cibuildwheel, but always build `master` and pull requests
-    if: github.repository != 'joerick/cibuildwheel' || github.ref == 'refs/heads/master' || github.event_name == 'pull_request'
-
     name: Test cibuildwheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Minor thing, but this change prevents the multiple pre-commit CI runs for origin branches and prevents the 'skipped' jobs from appearing
