### PR TITLE
Ensure modern version of Python in CIBW_BEFORE_ALL on manylinux

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -122,7 +122,7 @@ def build(options: BuildOptions) -> None:
 
                 if options.before_all:
                     env = docker.get_environment()
-                    env['PATH'] = f'/opt/python/cp38-cp38:{env["PATH"]}'
+                    env['PATH'] = f'/opt/python/cp38-cp38/bin:{env["PATH"]}'
                     env = options.environment.as_dictionary(env, executor=docker.environment_executor)
 
                     before_all_prepared = prepare_command(options.before_all, project=container_project_path, package=container_package_dir)

--- a/test/test_before_all.py
+++ b/test/test_before_all.py
@@ -26,10 +26,12 @@ def test(tmp_path):
         print("dummy text", file=ff)
 
     # build the wheels
+    before_all_command = '''python -c "import os;open('{project}/text_info.txt', 'w').write('sample text '+os.environ.get('TEST_VAL', ''))"'''
     actual_wheels = utils.cibuildwheel_run(project_dir, add_env={
         # write python version information to a temporary file, this is
         # checked in setup.py
-        'CIBW_BEFORE_ALL': '''python -c "import os;open('{project}/text_info.txt', 'w').write('sample text '+os.environ.get('TEST_VAL', ''))"''',
+        'CIBW_BEFORE_ALL': before_all_command,
+        'CIBW_BEFORE_ALL_LINUX': before_all_command + ''' && python -c "import sys; assert sys.version_info >= (3, 6)"''',
         'CIBW_ENVIRONMENT': "TEST_VAL='123'"
     })
 


### PR DESCRIPTION
I think this line is missing `bin/`: https://github.com/joerick/cibuildwheel/blob/2f4ed1fafc6661b1bcfef10c28b47d593e53dfa5/cibuildwheel/linux.py#L125

First a commit to make sure I'm correct, though.