### PR TITLE
Build wheels using QEMU emulation

### DIFF
--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -136,6 +136,7 @@ class BuildOptions(NamedTuple):
     test_requires: List[str]
     test_extras: str
     build_verbosity: int
+    use_binfmt: bool
 
 
 resources_dir = Path(__file__).resolve().parent / 'resources'


### PR DESCRIPTION
From the discussion in #364 I had an attempt at getting builds working using qemu/binfmt which is pretty seamless with Docker.

Running on a Core i7 x86_64 machine:

```
↳ python -m cibuildwheel --platform linux --print-build-identifiers
cp27-manylinux_x86_64
cp27-manylinux_x86_64
cp35-manylinux_x86_64
cp36-manylinux_x86_64
cp37-manylinux_x86_64
cp38-manylinux_x86_64
cp39-manylinux_x86_64
cp27-manylinux_i686
cp27-manylinux_i686
cp35-manylinux_i686
cp36-manylinux_i686
cp37-manylinux_i686
cp38-manylinux_i686
cp39-manylinux_i686
pp27-manylinux_x86_64
pp36-manylinux_x86_64
pp37-manylinux_x86_64

↳ python -m cibuildwheel --platform linux --print-build-identifiers --use-binfmt
cp27-manylinux_x86_64
cp27-manylinux_x86_64
cp35-manylinux_x86_64
cp36-manylinux_x86_64
cp37-manylinux_x86_64
cp38-manylinux_x86_64
cp39-manylinux_x86_64
cp27-manylinux_i686
cp27-manylinux_i686
cp35-manylinux_i686
cp36-manylinux_i686
cp37-manylinux_i686
cp38-manylinux_i686
cp39-manylinux_i686
pp27-manylinux_x86_64
pp36-manylinux_x86_64
pp37-manylinux_x86_64
cp35-manylinux_aarch64
cp36-manylinux_aarch64
cp37-manylinux_aarch64
cp38-manylinux_aarch64
cp39-manylinux_aarch64
cp35-manylinux_ppc64le
cp36-manylinux_ppc64le
cp37-manylinux_ppc64le
cp38-manylinux_ppc64le
cp39-manylinux_ppc64le
cp35-manylinux_s390x
cp36-manylinux_s390x
cp37-manylinux_s390x
cp38-manylinux_s390x
cp39-manylinux_s390x
```

```
$ russ @ sherlock in /tmp [19:29:56]
↳ git clone https://github.com/pyrogram/tgcrypto.git
Cloning into 'tgcrypto'...
remote: Enumerating objects: 17, done.
remote: Counting objects: 100% (17/17), done.
remote: Compressing objects: 100% (15/15), done.
remote: Total 276 (delta 7), reused 5 (delta 2), pack-reused 259
Receiving objects: 100% (276/276), 116.65 KiB | 291.00 KiB/s, done.
Resolving deltas: 100% (161/161), done.

$ russ @ sherlock in /tmp [19:30:02]
↳ cd tgcrypto 

$ russ @ sherlock in /tmp/tgcrypto on  master ● [19:30:04]
↳ CIBW_BUILD=cp39-manylinux_aarch64 python -m cibuildwheel --output-dir wheelhouse --platform linux --use-binfmt

     _ _       _ _   _       _           _
 ___|_| |_ _ _|_| |_| |_ _ _| |_ ___ ___| |
|  _| | . | | | | | . | | | |   | -_| -_| |
|___|_|___|___|_|_|___|_____|_|_|___|___|_|

cibuildwheel version 1.7.0

Build options:
  platform: 'linux'
  before_all: ''
  before_build: None
  before_test: None
  build_selector: BuildSelector('cp39-manylinux_aarch64')
  build_verbosity: 0
  dependency_constraints: DependencyConstraintsPosixPath('/home/russ/Devel/cibuildwheel/cibuildwheel/resources/constraints.txt'))
  environment: ParsedEnvironment([])
  manylinux_images: {'x86_64': 'quay.io/pypa/manylinux2010_x86_64:2020-11-11-201fb79', 'i686': 'quay.io/pypa/manylinux2010_i686:2020-11-11-201fb79', 'pypy_x86_64': 'pypywheels/manylinux2010-pypy_x86_64:2020-11-21-a03b9e9', 'aarch64': 'quay.io/pypa/manylinux2014_aarch64:2020-11-11-bc8ce45', 'ppc64le': 'quay.io/pypa/manylinux2014_ppc64le:2020-11-11-bc8ce45', 's390x': 'quay.io/pypa/manylinux2014_s390x:2020-11-11-bc8ce45'}
  output_dir: PosixPath('wheelhouse')
  package_dir: PosixPath('.')
  repair_command: 'auditwheel repair -w {dest_dir} {wheel}'
  test_command: None
  test_extras: ''
  test_requires: []

Here we go!

Starting Docker image quay.io/pypa/manylinux2014_aarch64:2020-11-11-bc8ce45...

ca13d42d27702eb6f775a9774d57d78ec421c0540c5ecd26987a978ed01d6082
    + /bin/true

                                                              ✓ 0.75s
Copying project into Docker...

    + mkdir -p /project

                                                              ✓ 0.32s

Building cp39-manylinux_aarch64 wheel
CPython 3.9 manylinux aarch64

Setting up build environment...

    + /opt/python/cp38-cp38/bin/python -c 'import sys, json, os; json.dump(os.environ.copy(), sys.stdout)'
    + which python
    + which pip

                                                              ✓ 0.94s
Building wheel...

    + rm -rf /tmp/cibuildwheel/built_wheel
    + mkdir -p /tmp/cibuildwheel/built_wheel
    + pip wheel /project -w /tmp/cibuildwheel/built_wheel --no-deps
Processing /project
Building wheels for collected packages: TgCrypto
  Building wheel for TgCrypto (setup.py): started
  Building wheel for TgCrypto (setup.py): finished with status 'done'
  Created wheel for TgCrypto: filename=TgCrypto-1.2.2-cp39-cp39-linux_aarch64.whl size=65370 sha256=b02b0adca3a65cc823b9c1fe09e0a1217a5e6d28c33c46ebf7f847e1194434ed
  Stored in directory: /tmp/pip-ephem-wheel-cache-irkf8ffx/wheels/b1/d1/e9/62441f1a701c6dcdb0d9ccfd73a0bfbac93e8cf297e5312e15
Successfully built TgCrypto
    + /opt/python/cp38-cp38/bin/python -c 'import sys, json, glob; json.dump(glob.glob('"'"'/tmp/cibuildwheel/built_wheel/*.whl'"'"'), sys.stdout)'
    + rm -rf /tmp/cibuildwheel/repaired_wheel
    + mkdir -p /tmp/cibuildwheel/repaired_wheel

                                                             ✓ 34.74s
Repairing wheel...

    + sh -c 'auditwheel repair -w /tmp/cibuildwheel/repaired_wheel /tmp/cibuildwheel/built_wheel/TgCrypto-1.2.2-cp39-cp39-linux_aarch64.whl'
INFO:auditwheel.main_repair:Repairing TgCrypto-1.2.2-cp39-cp39-linux_aarch64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_aarch64
INFO:auditwheel.wheeltools:New filename tags: manylinux2014_aarch64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp39-cp39-linux_aarch64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp39-cp39-manylinux2014_aarch64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /tmp/cibuildwheel/repaired_wheel/TgCrypto-1.2.2-cp39-cp39-manylinux2014_aarch64.whl
    + /opt/python/cp38-cp38/bin/python -c 'import sys, json, glob; json.dump(glob.glob('"'"'/tmp/cibuildwheel/repaired_wheel/*.whl'"'"'), sys.stdout)'
    + mkdir -p /output
    + mv /tmp/cibuildwheel/repaired_wheel/TgCrypto-1.2.2-cp39-cp39-manylinux2014_aarch64.whl /output

                                                              ✓ 5.39s

✓ cp39-manylinux_aarch64 finished in 41.37s
Copying wheels back to host...


                                                              ✓ 0.32s

$ russ @ sherlock in /tmp/tgcrypto on  master ✖︎ [19:30:57]
↳ ls
 tests/   tgcrypto/   wheelhouse/   COPYING   COPYING.lesser   MANIFEST.in   NOTICE   README.md   setup.py   tox.ini

$ russ @ sherlock in /tmp/tgcrypto on  master ✖︎ [19:31:00]
↳ ls wheelhouse 
 TgCrypto-1.2.2-cp39-cp39-manylinux2014_aarch64.whl
```