### PR TITLE
Bump pinned default manylinux2010 image version

### DIFF
--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,11 +1,11 @@
 [x86_64]
 manylinux1 = quay.io/pypa/manylinux1_x86_64:2020-11-11-0f1f128
-manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2020-11-11-201fb79
+manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de
 manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2020-11-11-bc8ce45
 
 [i686]
 manylinux1 = quay.io/pypa/manylinux1_i686:2020-11-11-0f1f128
-manylinux2010 = quay.io/pypa/manylinux2010_i686:2020-11-11-201fb79
+manylinux2010 = quay.io/pypa/manylinux2010_i686:2020-12-03-912b0de
 manylinux2014 = quay.io/pypa/manylinux2014_i686:2020-11-11-bc8ce45
 
 [pypy_x86_64]


### PR DESCRIPTION
The current pinned version of the manylinux2010 docker image has an
issue where it is trying to use EoL yum repositories
(see pypa/manylinux#836 for more details). The repository path has been
updated on the latest image. This commit bumps the manylinux2010 docker
image version to use the latest version to get this fix.