### PR TITLE
docs: use GitHub example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,16 @@ jobs:
         run: python -m pip install cibuildwheel==1.7.1
 
       - name: Build wheels
-        env:
-          CIBW_SKIP: "?p25-*" # Skip building Python 2.7 wheels on all platforms
         run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_SKIP: "cp27-* pp27-*"  # skip Python 2.7 wheels
 
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
 ```
 
-You can add a deploy job using [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish). For more information, including a full example of building on GitHub Actions with PyPI deploy, Travis CI, Appveyor, Azure Pipelines, or CircleCI, check out the [documentation](https://cibuildwheel.readthedocs.org) and the [examples](https://github.com/joerick/cibuildwheel/tree/master/examples).
+For more information, including building on Python 2, PyPI deployment, and the use of other CI services like Travis CI, Appveyor, Azure Pipelines, or CircleCI, check out the [documentation](https://cibuildwheel.readthedocs.org) and the [examples](https://github.com/joerick/cibuildwheel/tree/master/examples).
 
 Options
 -------

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Usage
 Example setup
 -------------
 
-To build manylinux, macOS, and Windows wheels on Github and make them availble for download after the job runs, you could use this `.github/workflows/wheels.yml`:
+To build manylinux, macOS, and Windows wheels on Github Actions, you could use this `.github/workflows/wheels.yml`:
 
 ```yaml
 name: Build
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
 
     steps:
       - uses: actions/checkout@v2
@@ -82,11 +82,9 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==1.7.1
 
-      - name: Install Visual C++ for Python 2.7
-        if: runner.os == 'Windows'
-        run: choco install vcpython27 -f -y
-
       - name: Build wheels
+        env:
+          CIBW_SKIP: "?p25-*" # Skip building Python 2.7 wheels on all platforms
         run: python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v2

--- a/examples/travis-ci-deploy.yml
+++ b/examples/travis-ci-deploy.yml
@@ -19,11 +19,6 @@ jobs:
         # make sure it's on PATH as 'python3'
         - ln -s /c/Python38/python.exe /c/Python38/python3.exe
 
-env:
-  global:
-    - TWINE_USERNAME=__token__
-    # Note: TWINE_PASSWORD is set to a PyPI API token in Travis settings
-
 install:
   - python3 -m pip install cibuildwheel==1.7.1
 
@@ -31,10 +26,11 @@ script:
   # build the wheels, put them into './wheelhouse'
   - python3 -m cibuildwheel --output-dir wheelhouse
 
-after_success:
-  # if the release was tagged, upload them to PyPI
-  - |
-    if [[ $TRAVIS_TAG ]]; then
-      python3 -m pip install twine
-      python3 -m twine upload wheelhouse/*.whl
-    fi
+deploy:
+  provider: pypi
+  username: "__token__"
+  skip_cleanup: true
+  on:
+    tags: true
+  password:
+    secure: "" # Set here

--- a/examples/travis-ci-deploy.yml
+++ b/examples/travis-ci-deploy.yml
@@ -33,4 +33,4 @@ deploy:
   on:
     tags: true
   password:
-    secure: "" # Set here
+    secure: "" # Set to an encrypted API token. See https://docs.travis-ci.com/user/deployment/pypi/


### PR DESCRIPTION
Swapping the readme example with GHA. Should we do deploy (properly) in the readme? I would rather think not, since it will make it a bit longer if we do it properly (cleaner and more modular). I've also approximately changed the Travis CI example to the correct deployment scheme. I didn't add mention of the trick I have to use to stop it from adding the SDist (important if you combine GHA + Travis for ARM, for example). Hopefully this is at least a starting point.
