### PR TITLE
Add no-clean option to pass through to pip wheel

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -84,6 +84,10 @@ def main() -> None:
                         action='store_true',
                         help='Print the build identifiers matched by the current invocation and exit.')
 
+    parser.add_argument('--no-clean',
+                        action='store_true',
+                        help='Pass along --no-clean option to pip wheel so the build directory is not removed')
+
     args = parser.parse_args()
 
     detect_obsolete_options()
@@ -216,6 +220,7 @@ def main() -> None:
         environment=environment,
         dependency_constraints=dependency_constraints,
         manylinux_images=manylinux_images,
+        no_clean=args.no_clean
     )
 
     # Python is buffering by default when running on the CI platforms, giving problems interleaving subprocess call output with unflushed calls to 'print'

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -184,6 +184,7 @@ def build(options: BuildOptions) -> None:
                         container_package_dir,
                         '-w', built_wheel_dir,
                         '--no-deps',
+                        '--no-clean' if options.no_clean else '',
                         *get_build_verbosity_extra_flags(options.build_verbosity)
                     ], env=env)
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -223,6 +223,7 @@ def build(options: BuildOptions) -> None:
                 options.package_dir.resolve(),
                 '-w', built_wheel_dir,
                 '--no-deps',
+                '--no-clean' if options.no_clean else '',
                 *get_build_verbosity_extra_flags(options.build_verbosity)
             ], env=env)
 

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -136,6 +136,7 @@ class BuildOptions(NamedTuple):
     test_requires: List[str]
     test_extras: str
     build_verbosity: int
+    no_clean: bool
 
 
 resources_dir = Path(__file__).resolve().parent / 'resources'

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -248,6 +248,7 @@ def build(options: BuildOptions) -> None:
                 options.package_dir.resolve(),
                 '-w', built_wheel_dir,
                 '--no-deps',
+                '--no-clean' if options.no_clean else '',
                 *get_build_verbosity_extra_flags(options.build_verbosity)
             ], env=env)
 


### PR DESCRIPTION
Thank you for all your work on this project!

This PR is a proposal for a new command line option. Although, I'm happy to change this to an environment variable option if that is preferred.

## New Option
The new option would be `--no-clean` which is simply passed through to the `pip wheel` call. This prevents `pip` from cleaning up the build directory.

## Use Case

The use case for this feature is for building binary extension wheels. If the build directory is cleaned up, then `auditwheel` might not have access to built libraries. 

In particular, I am working on incorporating `cibuildwheel` to the GitHub Actions flow for [CVC4](https://github.com/CVC4/CVC4) in [my fork](https://github.com/makaimann/CVC4/tree/pypi) using `scikit-build` and `Cython`. It is now able to build the wheel, but repairing the wheel with `auditwheel` fails because it cannot find the compiled `CVC4` library. This is because the build directory (`_skbuild`) is automatically cleaned up by `pip` before `auditwheel` is called. See the log [here](https://github.com/makaimann/CVC4/runs/1539577716?check_suite_focus=true). That run differs from a [working version](https://github.com/makaimann/CVC4/actions/runs/414334801) (using this branch of `cibuildwheel`) only by [this commit](https://github.com/makaimann/CVC4/commit/ccb7078ae3c8208e6175f786d12e197e45bd259f) which uses the PyPi release of `cibuildwheel`.

I also tried installing the built libraries outside of the `_skbuild` directory, but then got this error message:
```
skbuild.exceptions.SKBuildError:
9316
      CMake-installed files must be within the project root.
```

After searching online a bit, I was not able to find another solution to this `auditwheel` issue, which led to this PR. Please let me know if there's a better / standard way of handling this. Thanks for you time!