### PR TITLE
feat: add support for composite-actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,26 @@
+name: cibuildwheel
+description: 'Installs and runs cibuildwheel on the current runner'
+inputs:
+  package-dir:
+    description: 'Input directory, defaults to "."'
+    required: false
+    default: .
+  output-dir:
+    description: 'Folder to place the outputs in, defaults to "wheelhouse"'
+    required: false
+    default: wheelhouse
+branding:
+  icon: package
+  color: yellow
+
+runs:
+  using: composite
+  steps:
+
+    # This needs powershell-core because github.action path is a Windows-style
+    # path on Windows.  Powershell-core understands both types of paths.
+    - run: python -m pip install ${{ github.action_path }}
+      shell: pwsh
+
+    - run: python -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
+      shell: bash

--- a/bin/bump_version.py
+++ b/bin/bump_version.py
@@ -11,10 +11,13 @@ import urllib.parse
 
 config = [
     # file path, version find/replace format
-    ('cibuildwheel/__init__.py', "__version__ = '{}'"),
-    ('setup.py', "version='{}'"),
     ('README.md', "cibuildwheel=={}"),
+    ('cibuildwheel/__init__.py', "__version__ = '{}'"),
+    ('docs/faq.md', "cibuildwheel=={}"),
+    ('docs/faq.md', "cibuildwheel@v{}"),
+    ('docs/setup.md', "cibuildwheel@v{}"),
     ('examples/*', "cibuildwheel=={}"),
+    ('setup.py', "version='{}'"),
 ]
 
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,6 +17,8 @@ For more info on this file, check out the [docs](https://help.github.com/en/acti
 
 [`examples/github-deploy.yml`](https://github.com/joerick/cibuildwheel/blob/master/examples/github-deploy.yml) extends this minimal example with a demonstration of how to automatically upload the built wheels to PyPI.
 
+You can also use cibuildwheel directly as an action with `uses: joerick/cibuildwheel@v1.7.1`; this combines the download and run steps into a single action, and command line arguments are available via `with:`. This makes it easy to manage cibuildwheel updates via normal actions update mechanisms like dependabot, see [Automatic updates](faq.md#automatic-updates).
+
 # Azure Pipelines [linux/mac/windows] {: #azure-pipelines}
 
 To build Linux, Mac, and Windows wheels on Azure Pipelines, create a `azure-pipelines.yml` file in your repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
See https://github.com/joerick/cibuildwheel/discussions/492

Demo / tested here: https://github.com/scikit-hep/boost-histogram/pull/488.

Should we update the readme and/or examples? I've updated the readme but not the examples in the current state of the PR. I think we should also add a note on how to setup dependabot to update it - I first learned about it from a different GitHub action's readme, actually. Using pinned versions but having a bot make an update PR every so often is really ideal for CI. It really helps clarify when an update breaks your CI, or when you do. :)