### PR TITLE
style: isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,11 @@ repos:
   - id: mixed-line-ending
   - id: trailing-whitespace
 
+- repo: https://github.com/PyCQA/isort
+  rev: 5.7.0
+  hooks:
+  - id: isort
+
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.790
   hooks:

--- a/bin/bump_version.py
+++ b/bin/bump_version.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
-import click
-from pathlib import Path
-import os
-import cibuildwheel
-from packaging.version import Version, InvalidVersion
-import subprocess
 import glob
+import os
+import subprocess
 import urllib.parse
+from pathlib import Path
+
+import click
+from packaging.version import InvalidVersion, Version
+
+import cibuildwheel
 
 config = [
     # file path, version find/replace format

--- a/bin/make_dependency_update_pr.py
+++ b/bin/make_dependency_update_pr.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
 import os
+import textwrap
 import time
 from pathlib import Path
 from subprocess import run
 
 import click
-import textwrap
 
 
 def shell(cmd, **kwargs):

--- a/bin/projects.py
+++ b/bin/projects.py
@@ -11,17 +11,16 @@ Suggested usage:
 
 import builtins
 import functools
+import urllib.request
+import xml.dom.minidom
 from datetime import datetime
 from io import StringIO
-from typing import Dict, Any, List, Optional, TextIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TextIO
 
 import click
 import yaml
 from github import Github
-import urllib.request
-import xml.dom.minidom
-from pathlib import Path
-
 
 ICONS = (
     "appveyor",

--- a/bin/run_example_ci_configs.py
+++ b/bin/run_example_ci_configs.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 
 import os
-from pathlib import Path
 import shutil
-from subprocess import run
 import sys
 import textwrap
 import time
-import click
-from glob import glob
 from collections import namedtuple
+from glob import glob
+from pathlib import Path
+from subprocess import run
 from urllib.parse import quote
+
+import click
 
 
 def shell(cmd, **kwargs):

--- a/bin/sample_build.py
+++ b/bin/sample_build.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
 import subprocess
 import sys
-import argparse
 import tempfile
 from pathlib import Path
 

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -5,17 +5,13 @@ import textwrap
 import traceback
 from configparser import ConfigParser
 from pathlib import Path
-
 from typing import Any, Dict, List, Optional, Set, overload
 
 import cibuildwheel
 import cibuildwheel.linux
 import cibuildwheel.macos
 import cibuildwheel.windows
-from cibuildwheel.environment import (
-    EnvironmentParseError,
-    parse_environment,
-)
+from cibuildwheel.environment import EnvironmentParseError, parse_environment
 from cibuildwheel.util import (
     Architecture,
     BuildOptions,

--- a/cibuildwheel/docker_container.py
+++ b/cibuildwheel/docker_container.py
@@ -6,8 +6,8 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path, PurePath
-from typing import cast, IO, Dict, List, Optional, Sequence, Type
 from types import TracebackType
+from typing import IO, Dict, List, Optional, Sequence, Type, cast
 
 from .typing import PathOrStr, PopenBytes
 

--- a/cibuildwheel/environment.py
+++ b/cibuildwheel/environment.py
@@ -1,6 +1,6 @@
-import bashlex
-
 from typing import Dict, List, Mapping, Optional
+
+import bashlex
 
 from . import bashlex_eval
 

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -6,11 +6,16 @@ from typing import List, NamedTuple, Set
 
 from .docker_container import DockerContainer
 from .logger import log
-from .util import (
-    Architecture, BuildOptions, BuildSelector, NonPlatformWheelError,
-    allowed_architectures_check, get_build_verbosity_extra_flags, prepare_command,
-)
 from .typing import PathOrStr
+from .util import (
+    Architecture,
+    BuildOptions,
+    BuildSelector,
+    NonPlatformWheelError,
+    allowed_architectures_check,
+    get_build_verbosity_extra_flags,
+    prepare_command,
+)
 
 
 class PythonConfiguration(NamedTuple):

--- a/cibuildwheel/logger.py
+++ b/cibuildwheel/logger.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 import time
-from typing import Optional, Union, AnyStr, IO
+from typing import IO, AnyStr, Optional, Union
 
 from cibuildwheel.util import CIProvider, detect_ci_provider
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -9,10 +9,18 @@ from typing import Dict, List, NamedTuple, Optional, Sequence
 
 from .environment import ParsedEnvironment
 from .logger import log
-from .util import (BuildOptions, BuildSelector, NonPlatformWheelError,
-                   download, get_build_verbosity_extra_flags, get_pip_script,
-                   install_certifi_script, prepare_command, allowed_architectures_check)
 from .typing import PathOrStr
+from .util import (
+    BuildOptions,
+    BuildSelector,
+    NonPlatformWheelError,
+    allowed_architectures_check,
+    download,
+    get_build_verbosity_extra_flags,
+    get_pip_script,
+    install_certifi_script,
+    prepare_command,
+)
 
 
 def call(args: Sequence[PathOrStr], env: Optional[Dict[str, str]] = None, cwd: Optional[str] = None, shell: bool = False) -> int:

--- a/cibuildwheel/resources/get-pip.py
+++ b/cibuildwheel/resources/get-pip.py
@@ -23,8 +23,8 @@
 import os.path
 import pkgutil
 import shutil
-import sys
 import struct
+import sys
 import tempfile
 
 # Useful for very coarse version differentiation.

--- a/cibuildwheel/resources/install_certifi.py
+++ b/cibuildwheel/resources/install_certifi.py
@@ -29,6 +29,7 @@ def main():
                            "-E", "-s", "-m", "pip", "install", "--upgrade", "certifi"])
 
     import certifi
+
     # change working directory to the default SSL directory
     os.chdir(openssl_dir)
     relpath_to_certifi_cafile = os.path.relpath(certifi.where())

--- a/cibuildwheel/typing.py
+++ b/cibuildwheel/typing.py
@@ -1,7 +1,6 @@
-from typing import Union, TYPE_CHECKING
 import os
 import subprocess
-
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     PopenBytes = subprocess.Popen[bytes]

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -1,9 +1,9 @@
+import functools
 import os
 import platform as platform_module
 import re
 import ssl
 import sys
-import functools
 import textwrap
 import urllib.request
 from enum import Enum

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -11,10 +11,18 @@ import toml
 
 from .environment import ParsedEnvironment
 from .logger import log
-from .util import (Architecture, BuildOptions, BuildSelector, NonPlatformWheelError,
-                   download, get_build_verbosity_extra_flags, get_pip_script,
-                   prepare_command, allowed_architectures_check)
 from .typing import PathOrStr
+from .util import (
+    Architecture,
+    BuildOptions,
+    BuildSelector,
+    NonPlatformWheelError,
+    allowed_architectures_check,
+    download,
+    get_build_verbosity_extra_flags,
+    get_pip_script,
+    prepare_command,
+)
 
 IS_RUNNING_ON_AZURE = Path('C:\\hostedtoolcache').exists()
 IS_RUNNING_ON_TRAVIS = os.environ.get('TRAVIS_OS_NAME') == 'windows'

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,3 +111,7 @@ ignore_missing_imports = True
 
 [mypy-bashlex.*]
 ignore_missing_imports = True
+
+[tool:isort]
+profile=black
+multi_line_output=3

--- a/test/test_0_basic.py
+++ b/test/test_0_basic.py
@@ -1,8 +1,10 @@
 import platform
 import textwrap
+
 import pytest
 
 from cibuildwheel.logger import Logger
+
 from . import test_projects, utils
 
 basic_project = test_projects.new_c_project(

--- a/test/test_before_all.py
+++ b/test/test_before_all.py
@@ -1,9 +1,9 @@
-import pytest
 import subprocess
 import textwrap
 
-from . import utils
-from . import test_projects
+import pytest
+
+from . import test_projects, utils
 
 project_with_before_build_asserts = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(r'''

--- a/test/test_before_build.py
+++ b/test/test_before_build.py
@@ -1,9 +1,9 @@
-import pytest
 import subprocess
 import textwrap
 
-from . import utils
-from . import test_projects
+import pytest
+
+from . import test_projects, utils
 
 project_with_before_build_asserts = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(r'''

--- a/test/test_before_test.py
+++ b/test/test_before_test.py
@@ -1,5 +1,4 @@
-from . import test_projects
-from . import utils
+from . import test_projects, utils
 
 before_test_project = test_projects.new_c_project()
 before_test_project.files['test/spam_test.py'] = r'''

--- a/test/test_build_skip.py
+++ b/test/test_build_skip.py
@@ -1,7 +1,6 @@
 import textwrap
 
-from . import utils
-from . import test_projects
+from . import test_projects, utils
 
 project_with_skip_asserts = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(r'''

--- a/test/test_dependency_versions.py
+++ b/test/test_dependency_versions.py
@@ -1,11 +1,11 @@
 import re
-import pytest
 import textwrap
+
+import pytest
+
 import cibuildwheel.util
 
-from . import utils
-from . import test_projects
-
+from . import test_projects, utils
 
 project_with_expected_version_checks = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(r'''

--- a/test/test_docker_images.py
+++ b/test/test_docker_images.py
@@ -3,8 +3,7 @@ import textwrap
 
 import pytest
 
-from . import utils
-from . import test_projects
+from . import test_projects, utils
 
 dockcross_only_project = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(r'''

--- a/test/test_emulation.py
+++ b/test/test_emulation.py
@@ -1,8 +1,8 @@
 import subprocess
-import pytest
-from . import utils
-from . import test_projects
 
+import pytest
+
+from . import test_projects, utils
 
 project_with_a_test = test_projects.new_c_project()
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -1,10 +1,10 @@
 import os
-import pytest
 import subprocess
 import textwrap
-from . import utils
-from . import test_projects
 
+import pytest
+
+from . import test_projects, utils
 
 project_with_environment_asserts = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(r'''

--- a/test/test_manylinuxXXXX_only.py
+++ b/test/test_manylinuxXXXX_only.py
@@ -3,8 +3,7 @@ import textwrap
 
 import pytest
 
-from . import utils
-from . import test_projects
+from . import test_projects, utils
 
 # TODO: specify these at runtime according to manylinux_image
 project_with_manylinux_symbols = test_projects.new_c_project(

--- a/test/test_pep518.py
+++ b/test/test_pep518.py
@@ -1,7 +1,7 @@
-import textwrap
-from . import test_projects
-from . import utils
 import os
+import textwrap
+
+from . import test_projects, utils
 
 basic_project = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(

--- a/test/test_projects/base.py
+++ b/test/test_projects/base.py
@@ -1,9 +1,7 @@
 from pathlib import Path
+from typing import Any, Dict, Union
 
 import jinja2
-
-from typing import Union, Dict, Any
-
 
 FilesDict = Dict[str, Union[str, jinja2.Template]]
 TemplateContext = Dict[str, Any]

--- a/test/test_projects/c.py
+++ b/test/test_projects/c.py
@@ -1,6 +1,6 @@
 import jinja2
-from .base import TestProject
 
+from .base import TestProject
 
 SPAM_C_TEMPLATE = r'''
 #include <Python.h>

--- a/test/test_pure_wheel.py
+++ b/test/test_pure_wheel.py
@@ -1,6 +1,8 @@
 import subprocess
-import pytest
 from test import test_projects
+
+import pytest
+
 from . import utils
 
 pure_python_project = test_projects.TestProject()

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -1,7 +1,6 @@
 import textwrap
 
-from . import utils
-from . import test_projects
+from . import test_projects, utils
 
 project_with_ssl_tests = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(r'''

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4,8 +4,7 @@ import textwrap
 
 import pytest
 
-from . import utils
-from . import test_projects
+from . import test_projects, utils
 
 project_with_a_test = test_projects.new_c_project(
     setup_cfg_add=textwrap.dedent(r'''

--- a/test/test_troubleshooting.py
+++ b/test/test_troubleshooting.py
@@ -1,7 +1,9 @@
 import subprocess
+
 import pytest
-from .test_projects import TestProject
+
 from . import utils
+from .test_projects import TestProject
 
 so_file_project = TestProject()
 

--- a/test/test_unicode.py
+++ b/test/test_unicode.py
@@ -2,8 +2,7 @@ import textwrap
 
 import pytest
 
-from . import utils
-from . import test_projects
+from . import test_projects, utils
 
 project_with_unicode = test_projects.new_c_project(
     spam_c_function_add=textwrap.dedent(r'''

--- a/unit_test/dependency_constraints_test.py
+++ b/unit_test/dependency_constraints_test.py
@@ -1,6 +1,6 @@
-from cibuildwheel.util import DependencyConstraints
-
 from pathlib import Path
+
+from cibuildwheel.util import DependencyConstraints
 
 
 def test_defaults():

--- a/unit_test/download_test.py
+++ b/unit_test/download_test.py
@@ -1,9 +1,9 @@
-import certifi
-import pytest
 import ssl
 
-from cibuildwheel.util import download
+import certifi
+import pytest
 
+from cibuildwheel.util import download
 
 DOWNLOAD_URL = 'https://raw.githubusercontent.com/joerick/cibuildwheel/v1.6.3/requirements-dev.txt'
 

--- a/unit_test/main_tests/conftest.py
+++ b/unit_test/main_tests/conftest.py
@@ -4,12 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from cibuildwheel import (
-    linux,
-    macos,
-    util,
-    windows,
-)
+from cibuildwheel import linux, macos, util, windows
 
 
 class ArgsInterceptor:

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -8,7 +8,6 @@ from cibuildwheel.__main__ import main
 from cibuildwheel.environment import ParsedEnvironment
 from cibuildwheel.util import BuildSelector
 
-
 # CIBW_PLATFORM is tested in main_platform_test.py
 
 

--- a/unit_test/main_tests/main_platform_test.py
+++ b/unit_test/main_tests/main_platform_test.py
@@ -1,12 +1,11 @@
 import platform as platform_module
-from cibuildwheel.util import Architecture
 import sys
 
 import pytest
+from conftest import MOCK_PACKAGE_DIR  # noqa: I100
 
 from cibuildwheel.__main__ import main
-
-from conftest import MOCK_PACKAGE_DIR  # noqa: I100
+from cibuildwheel.util import Architecture
 
 
 def test_unknown_platform_non_ci(monkeypatch, capsys):


### PR DESCRIPTION
This actually can do full Black-style includes, I like it. :) Discussed in #518.

- style: isort
- style: run isort

This is Black-style, which I like - short includes are bundled onto one line, longer ones are one-per line. You can get merge conflicts for the short includes, but hopefully they are not changed often? And matching changes are okay.

Sticking configs in setup.cfg instead of pyproject.toml because mypy and flake8 don't support that yet. (Flake8 may never :( )
