### PR TITLE
feat: support brace expansion in BUILD/SKIP

### DIFF
--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -7,13 +7,13 @@ import sys
 import textwrap
 import urllib.request
 from enum import Enum
-from fnmatch import fnmatch
 from pathlib import Path
 from time import sleep
 from typing import Dict, List, NamedTuple, Optional, Set
 
 import certifi
 import toml
+import wcmatch.fnmatch as fnmatch
 
 from .environment import ParsedEnvironment
 from .typing import PathOrStr, PlatformName
@@ -61,9 +61,9 @@ class BuildSelector:
         self.skip_patterns = skip_config.split()
 
     def __call__(self, build_id: str) -> bool:
-        def match_any(patterns: List[str]) -> bool:
-            return any(fnmatch(build_id, pattern) for pattern in patterns)
-        return match_any(self.build_patterns) and not match_any(self.skip_patterns)
+        patterns = self.build_patterns + [f"!{v}" for v in self.skip_patterns]
+        result: bool = fnmatch.fnmatch(build_id, patterns, flags=fnmatch.NEGATEALL | fnmatch.BRACE | fnmatch.NEGATE)
+        return result
 
     def __repr__(self) -> str:
         if not self.skip_patterns:

--- a/docs/options.md
+++ b/docs/options.md
@@ -75,7 +75,7 @@ Space-separated list of builds to build and skip. Each build has an identifier l
 
 When both options are specified, both conditions are applied and only builds with a tag that matches `CIBW_BUILD` and does not match `CIBW_SKIP` will be built.
 
-When setting the options, you can use shell-style globbing syntax (as per [`fnmatch`](https://docs.python.org/3/library/fnmatch.html)). All the build identifiers supported by cibuildwheel are shown below:
+When setting the options, you can use shell-style globbing syntax (as per [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) and expanded by [`bracex`](https://pypi.org/project/bracex/)). All the build identifiers supported by cibuildwheel are shown below:
 
 <div class="build-id-table-marker"></div>
 
@@ -89,7 +89,7 @@ When setting the options, you can use shell-style globbing syntax (as per [`fnma
 | Python 3.9      | cp39-macosx_x86_64  | cp39-manylinux_x86_64  | cp39-manylinux_i686  | cp39-win_amd64  | cp39-win32     | cp39-manylinux_aarch64 | cp39-manylinux_ppc64le | cp39-manylinux_s390x |
 | PyPy 2.7 v7.3.3 | pp27-macosx_x86_64  | pp27-manylinux_x86_64  |                      |                 | pp27-win32     |                        |                        |                      |
 | PyPy 3.6 v7.3.3 | pp36-macosx_x86_64  | pp36-manylinux_x86_64  |                      |                 | pp36-win32     |                        |                        |                      |
-| PyPy 3.7 (beta) v7.3.3 | pp37-macosx_x86_64  | pp37-manylinux_x86_64  |                      |                 | pp37-win32     |                        |                        |                      |
+| PyPy 3.7 (beta) v7.3.3 | pp37-macosx_x86_64  | pp37-manylinux_x86_64  |               |                 | pp37-win32     |                        |                        |                      |
 
 
 The list of supported and currently selected build identifiers can also be retrieved by passing the `--print-build-identifiers` flag to `cibuildwheel`.
@@ -124,12 +124,12 @@ CIBW_SKIP: cp27-* cp35-*
 # Skip Python 3.6 on Linux
 CIBW_SKIP: cp36-manylinux*
 
-# Only build on Python 3 and skip 32-bit builds
-CIBW_BUILD: cp3?-*
+# Only build on Python 3 (ready for 3.10 when it comes) and skip 32-bit builds
+CIBW_BUILD: cp3{?,??}-*
 CIBW_SKIP: "*-win32 *-manylinux_i686"
 
 # Only build PyPy and CPython 3
-CIBW_BUILD: pp* cp3?-*
+CIBW_BUILD: pp* cp3{?,??}-*
 
 # Disable building PyPy wheels on all platforms
 CIBW_SKIP: pp*

--- a/docs/options.md
+++ b/docs/options.md
@@ -125,11 +125,11 @@ CIBW_SKIP: cp27-* cp35-*
 CIBW_SKIP: cp36-manylinux*
 
 # Only build on Python 3 (ready for 3.10 when it comes) and skip 32-bit builds
-CIBW_BUILD: cp3{?,??}-*
+CIBW_BUILD: {cp,pp}3*-*
 CIBW_SKIP: "*-win32 *-manylinux_i686"
 
 # Only build PyPy and CPython 3
-CIBW_BUILD: pp* cp3{?,??}-*
+CIBW_BUILD: pp* cp3*-*
 
 # Disable building PyPy wheels on all platforms
 CIBW_SKIP: pp*

--- a/docs/options.md
+++ b/docs/options.md
@@ -75,7 +75,7 @@ Space-separated list of builds to build and skip. Each build has an identifier l
 
 When both options are specified, both conditions are applied and only builds with a tag that matches `CIBW_BUILD` and does not match `CIBW_SKIP` will be built.
 
-When setting the options, you can use shell-style globbing syntax (as per [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) and expanded by [`bracex`](https://pypi.org/project/bracex/)). All the build identifiers supported by cibuildwheel are shown below:
+When setting the options, you can use shell-style globbing syntax, as per [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) with the addition of curly bracket syntax `{option1,option2}`, provided by [`bracex`](https://pypi.org/project/bracex/). All the build identifiers supported by cibuildwheel are shown below:
 
 <div class="build-id-table-marker"></div>
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     bashlex!=0.13
     toml
     certifi
-    wcmatch
+    bracex
     typing_extensions; python_version < '3.8'
     importlib_resources>=1.4; python_version < '3.9'
 
@@ -118,7 +118,7 @@ ignore_missing_imports = True
 [mypy-toml.*]
 ignore_missing_imports = True
 
-[mypy-wcmatch.*]
+[mypy-bracex.*]
 ignore_missing_imports = True
 
 [tool:isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     bashlex!=0.13
     toml
     certifi
+    wcmatch
     typing_extensions; python_version < '3.8'
     importlib_resources>=1.4; python_version < '3.9'
 
@@ -115,6 +116,9 @@ ignore_missing_imports = True
 
 # Has type stubs, but no pyproject.toml or .pyi files in the wheel.
 [mypy-toml.*]
+ignore_missing_imports = True
+
+[mypy-wcmatch.*]
 ignore_missing_imports = True
 
 [tool:isort]

--- a/unit_test/build_selector_test.py
+++ b/unit_test/build_selector_test.py
@@ -59,3 +59,13 @@ def test_build_and_skip():
     assert not build_selector('cp27-win_amd64')
     assert build_selector('cp36-win_amd64')
     assert not build_selector('cp37-win_amd64')
+
+
+def test_build_braces():
+    build_selector = BuildSelector(build_config="cp{36,37}*", skip_config="")
+
+    assert not build_selector('cp27-manylinux1_x86_64')
+    assert build_selector('cp36-manylinux1_x86_64')
+    assert build_selector('cp37-manylinux1_x86_64')
+    assert not build_selector('cp38-manylinux1_x86_64')
+    assert not build_selector('cp39-manylinux1_x86_64')


### PR DESCRIPTION
This adds support for `{}`.

TODO for getting this ready:

- [x] Update docs to mention the new feature (mentioned above).
- [x] How about updating the `cp3?-*` example to be compatible with Python 3.10?
- [x] Add tests for the new features
- Add a javascript version to the docs. [This looks pretty close](https://github.com/grob/fnmatch), actually. We can also iterate on [my demo](https://jsfiddle.net/henryiii/btuon0hy/1/show). (separate PR)

