### PR TITLE
feat: CIBW_TEST_SKIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Options
 |   | [`CIBW_BEFORE_TEST`](https://cibuildwheel.readthedocs.io/en/stable/options/#before-test)  | Execute a shell command before testing each wheel |
 |   | [`CIBW_TEST_REQUIRES`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-requires)  | Install Python dependencies before running the tests |
 |   | [`CIBW_TEST_EXTRAS`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-extras)  | Install your wheel for testing using extras_require |
+|   | [`CIBW_TEST_SKIP`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-skip)  | Skip running tests on some builds |
 | **Other** | [`CIBW_BUILD_VERBOSITY`](https://cibuildwheel.readthedocs.io/en/stable/options/#build-verbosity)  | Increase/decrease the output of pip wheel |
 
 

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -140,6 +140,7 @@ def main() -> None:
         assert_never(platform)
 
     build_config, skip_config = os.environ.get('CIBW_BUILD', '*'), os.environ.get('CIBW_SKIP', '')
+    test_skip = os.environ.get('CIBW_TEST_SKIP', '')
     environment_config = get_option_from_environment('CIBW_ENVIRONMENT', platform=platform, default='')
     before_all = get_option_from_environment('CIBW_BEFORE_ALL', platform=platform, default='')
     before_build = get_option_from_environment('CIBW_BEFORE_BUILD', platform=platform)
@@ -152,6 +153,7 @@ def main() -> None:
     build_verbosity_str = get_option_from_environment('CIBW_BUILD_VERBOSITY', platform=platform, default='')
 
     build_selector = BuildSelector(build_config, skip_config)
+    test_selector = BuildSelector("*", test_skip)
 
     try:
         environment = parse_environment(environment_config)
@@ -236,6 +238,7 @@ def main() -> None:
         before_all=before_all,
         build_verbosity=build_verbosity,
         build_selector=build_selector,
+        test_selector=test_selector,
         repair_command=repair_command,
         environment=environment,
         dependency_constraints=dependency_constraints,

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -18,6 +18,7 @@ from cibuildwheel.util import (
     BuildOptions,
     BuildSelector,
     DependencyConstraints,
+    TestSelector,
     Unbuffered,
     detect_ci_provider,
     resources_dir,
@@ -152,8 +153,8 @@ def main() -> None:
     test_extras = get_option_from_environment('CIBW_TEST_EXTRAS', platform=platform, default='')
     build_verbosity_str = get_option_from_environment('CIBW_BUILD_VERBOSITY', platform=platform, default='')
 
-    build_selector = BuildSelector(build_config, skip_config)
-    test_selector = BuildSelector("*", test_skip)
+    build_selector = BuildSelector(build_config=build_config, skip_config=skip_config)
+    test_selector = TestSelector(skip_config=test_skip)
 
     try:
         environment = parse_environment(environment_config)

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -183,7 +183,7 @@ def build(options: BuildOptions) -> None:
 
                     repaired_wheels = docker.glob(repaired_wheel_dir, '*.whl')
 
-                    if options.test_command:
+                    if options.test_command and options.test_selector(config.identifier):
                         log.step('Testing wheel...')
 
                         # set up a virtual environment to install and test from, to make sure

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -252,7 +252,7 @@ def build(options: BuildOptions) -> None:
 
             repaired_wheel = next(repaired_wheel_dir.glob('*.whl'))
 
-            if options.test_command:
+            if options.test_command and options.test_selector(config.identifier):
                 log.step('Testing wheel...')
                 # set up a virtual environment to install and test from, to make sure
                 # there are no dependencies that were pulled in at build time.

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -204,6 +204,7 @@ class BuildOptions(NamedTuple):
     package_dir: Path
     output_dir: Path
     build_selector: BuildSelector
+    test_selector: BuildSelector
     architectures: Set[Architecture]
     environment: ParsedEnvironment
     before_all: str

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -55,7 +55,12 @@ def read_python_configs(config: PlatformName) -> List[Dict[str, str]]:
     return results
 
 
-class IndentifierSelector:
+class IdentifierSelector:
+    """
+    This class holds a set of build/skip patterns. You call an instance with a
+    build identifier, and it returns True if that identifier should be
+    included.
+    """
     def __init__(self, *, build_config: str, skip_config: str):
         self.build_patterns = build_config.split()
         self.skip_patterns = skip_config.split()
@@ -72,11 +77,11 @@ class IndentifierSelector:
             return f'{self.__class__.__name__}({" ".join(self.build_patterns)!r} - {" ".join(self.skip_patterns)!r})'
 
 
-class BuildSelector(IndentifierSelector):
+class BuildSelector(IdentifierSelector):
     pass
 
 
-class TestSelector(IndentifierSelector):
+class TestSelector(IdentifierSelector):
     def __init__(self, *, skip_config: str):
         super().__init__(build_config="*", skip_config=skip_config)
 

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -55,8 +55,8 @@ def read_python_configs(config: PlatformName) -> List[Dict[str, str]]:
     return results
 
 
-class BuildSelector:
-    def __init__(self, build_config: str, skip_config: str):
+class IndentifierSelector:
+    def __init__(self, *, build_config: str, skip_config: str):
         self.build_patterns = build_config.split()
         self.skip_patterns = skip_config.split()
 
@@ -67,9 +67,18 @@ class BuildSelector:
 
     def __repr__(self) -> str:
         if not self.skip_patterns:
-            return f'BuildSelector({" ".join(self.build_patterns)!r})'
+            return f'{self.__class__.__name__}({" ".join(self.build_patterns)!r})'
         else:
-            return f'BuildSelector({" ".join(self.build_patterns)!r} - {" ".join(self.skip_patterns)!r})'
+            return f'{self.__class__.__name__}({" ".join(self.build_patterns)!r} - {" ".join(self.skip_patterns)!r})'
+
+
+class BuildSelector(IndentifierSelector):
+    pass
+
+
+class TestSelector(IndentifierSelector):
+    def __init__(self, *, skip_config: str):
+        super().__init__(build_config="*", skip_config=skip_config)
 
 
 # Taken from https://stackoverflow.com/a/107717
@@ -204,7 +213,6 @@ class BuildOptions(NamedTuple):
     package_dir: Path
     output_dir: Path
     build_selector: BuildSelector
-    test_selector: BuildSelector
     architectures: Set[Architecture]
     environment: ParsedEnvironment
     before_all: str
@@ -213,6 +221,7 @@ class BuildOptions(NamedTuple):
     manylinux_images: Optional[Dict[str, str]]
     dependency_constraints: Optional[DependencyConstraints]
     test_command: Optional[str]
+    test_selector: TestSelector
     before_test: Optional[str]
     test_requires: List[str]
     test_extras: str

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -277,7 +277,7 @@ def build(options: BuildOptions) -> None:
 
             repaired_wheel = next(repaired_wheel_dir.glob('*.whl'))
 
-            if options.test_command:
+            if options.test_command and options.test_selector(config.identifier):
                 log.step('Testing wheel...')
                 # set up a virtual environment to install and test from, to make sure
                 # there are no dependencies that were pulled in at build time.

--- a/docs/options.md
+++ b/docs/options.md
@@ -518,6 +518,18 @@ Platform-specific variants also available:<br/>
 CIBW_TEST_EXTRAS: test,qt
 ```
 
+### `CIBW_TEST_SKIP` {: #test-skip}
+> Match selectors that should be skipped
+
+This will skip testing on any identifiers that match the given skip patterns (see [`CIBW_SKIP`](#build-skip)). This can be used to mask out tests for wheels that have missing dependencies upstream that are slow or hard to build, or to mask up slow tests on emulated architectures.
+
+#### Examples
+
+```yaml
+# Will avoid testing on emulated architectures
+CIBW_TEST_SKIP: "*-manylinux_{aarch64,ppc64le,s390x}"
+```
+
 
 ## Other
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -519,7 +519,7 @@ CIBW_TEST_EXTRAS: test,qt
 ```
 
 ### `CIBW_TEST_SKIP` {: #test-skip}
-> Match selectors that should be skipped
+> Skip running tests on some builds
 
 This will skip testing on any identifiers that match the given skip patterns (see [`CIBW_SKIP`](#build-skip)). This can be used to mask out tests for wheels that have missing dependencies upstream that are slow or hard to build, or to mask up slow tests on emulated architectures.
 


### PR DESCRIPTION
Addressing #529 (no universal yet, but that can be added when #484 is in). Just a SKIP, since that seemed to be the consensus? Without the `!` syntax in BUILD I guess only SKIP makes sense (though it is very easy to add).
