### PR TITLE
fix: improve correctness of exits

### DIFF
--- a/bin/bump_version.py
+++ b/bin/bump_version.py
@@ -4,11 +4,11 @@
 import glob
 import os
 import subprocess
+import sys
 import urllib.parse
 from pathlib import Path
 
 import click
-from click.exceptions import Exit
 from packaging.version import InvalidVersion, Version
 
 import cibuildwheel
@@ -53,7 +53,7 @@ def bump_version():
 
     if repo_has_uncommitted_changes:
         print('error: Uncommitted changes detected.')
-        raise Exit(1)
+        sys.exit(1)
 
     print(              'Current version:', current_version)  # noqa
     new_version = input('    New version: ').strip()
@@ -63,7 +63,7 @@ def bump_version():
     except InvalidVersion:
         print("error: This version doesn't conform to PEP440")
         print('       https://www.python.org/dev/peps/pep-0440/')
-        raise Exit(1)
+        sys.exit(1)
 
     actions = []
 
@@ -72,7 +72,7 @@ def bump_version():
 
         if not paths:
             print(f'error: Pattern {path_pattern} didn’t match any files')
-            raise Exit(1)
+            sys.exit(1)
 
         find_pattern = version_pattern.format(current_version)
         replace_pattern = version_pattern.format(new_version)
@@ -88,7 +88,7 @@ def bump_version():
 
         if not found_at_least_one_file_needing_update:
             print(f'error: Didn’t find any occurrences of “{find_pattern}” in “{path_pattern}”')
-            raise Exit(1)
+            sys.exit(1)
 
     print()
     print("Here's the plan:")
@@ -106,7 +106,7 @@ def bump_version():
 
     if answer != 'y':
         print('Aborted')
-        raise Exit(1)
+        sys.exit(1)
 
     for path, find, replace in actions:
         contents = path.read_text(encoding='utf8')

--- a/bin/bump_version.py
+++ b/bin/bump_version.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+
 import glob
 import os
 import subprocess
@@ -7,6 +8,7 @@ import urllib.parse
 from pathlib import Path
 
 import click
+from click.exceptions import Exit
 from packaging.version import InvalidVersion, Version
 
 import cibuildwheel
@@ -23,6 +25,8 @@ config = [
 ]
 
 
+# This file requires Python 3.7
+# Setting -> None will cause MyPy to notice this.
 @click.command()
 def bump_version():
     current_version = cibuildwheel.__version__
@@ -49,7 +53,7 @@ def bump_version():
 
     if repo_has_uncommitted_changes:
         print('error: Uncommitted changes detected.')
-        exit(1)
+        raise Exit(1)
 
     print(              'Current version:', current_version)  # noqa
     new_version = input('    New version: ').strip()
@@ -59,7 +63,7 @@ def bump_version():
     except InvalidVersion:
         print("error: This version doesn't conform to PEP440")
         print('       https://www.python.org/dev/peps/pep-0440/')
-        exit(1)
+        raise Exit(1)
 
     actions = []
 
@@ -68,7 +72,7 @@ def bump_version():
 
         if not paths:
             print(f'error: Pattern {path_pattern} didn’t match any files')
-            exit(1)
+            raise Exit(1)
 
         find_pattern = version_pattern.format(current_version)
         replace_pattern = version_pattern.format(new_version)
@@ -83,8 +87,8 @@ def bump_version():
                 )
 
         if not found_at_least_one_file_needing_update:
-            print(f'error: Didn’t find any occurences of “{find_pattern}” in “{path_pattern}”')
-            exit(1)
+            print(f'error: Didn’t find any occurrences of “{find_pattern}” in “{path_pattern}”')
+            raise Exit(1)
 
     print()
     print("Here's the plan:")
@@ -102,7 +106,7 @@ def bump_version():
 
     if answer != 'y':
         print('Aborted')
-        exit(1)
+        raise Exit(1)
 
     for path, find, replace in actions:
         contents = path.read_text(encoding='utf8')

--- a/bin/make_dependency_update_pr.py
+++ b/bin/make_dependency_update_pr.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from subprocess import run
 
 import click
+from click.exceptions import Exit
 
 
 def shell(cmd, **kwargs):
@@ -26,7 +27,7 @@ def main():
 
     if git_repo_has_changes():
         print('Your git repo has uncommitted changes. Commit or stash before continuing.')
-        exit(1)
+        raise Exit(1)
 
     previous_branch = shell('git rev-parse --abbrev-ref HEAD',
                             check=True,

--- a/bin/make_dependency_update_pr.py
+++ b/bin/make_dependency_update_pr.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
 import os
+import sys
 import textwrap
 import time
 from pathlib import Path
 from subprocess import run
 
 import click
-from click.exceptions import Exit
 
 
 def shell(cmd, **kwargs):
@@ -27,7 +27,7 @@ def main():
 
     if git_repo_has_changes():
         print('Your git repo has uncommitted changes. Commit or stash before continuing.')
-        raise Exit(1)
+        sys.exit(1)
 
     previous_branch = shell('git rev-parse --abbrev-ref HEAD',
                             check=True,

--- a/bin/run_example_ci_configs.py
+++ b/bin/run_example_ci_configs.py
@@ -12,6 +12,7 @@ from subprocess import run
 from urllib.parse import quote
 
 import click
+from click.exceptions import Exit
 
 
 def shell(cmd, **kwargs):
@@ -98,7 +99,7 @@ def run_example_ci_configs(config_files=None):
 
     if git_repo_has_changes():
         print('Your git repo has uncommitted changes. Commit or stash before continuing.')
-        exit(1)
+        raise Exit(1)
 
     previous_branch = shell('git rev-parse --abbrev-ref HEAD',
                             check=True,

--- a/bin/run_example_ci_configs.py
+++ b/bin/run_example_ci_configs.py
@@ -12,7 +12,6 @@ from subprocess import run
 from urllib.parse import quote
 
 import click
-from click.exceptions import Exit
 
 
 def shell(cmd, **kwargs):
@@ -99,7 +98,7 @@ def run_example_ci_configs(config_files=None):
 
     if git_repo_has_changes():
         print('Your git repo has uncommitted changes. Commit or stash before continuing.')
-        raise Exit(1)
+        sys.exit(1)
 
     previous_branch = shell('git rev-parse --abbrev-ref HEAD',
                             check=True,

--- a/bin/sample_build.py
+++ b/bin/sample_build.py
@@ -22,4 +22,4 @@ if __name__ == '__main__':
         options.project_python_path, project_dir
     ], check=True)
 
-    exit(subprocess.run(['cibuildwheel'], cwd=project_dir).returncode)
+    sys.exit(subprocess.run(['cibuildwheel'], cwd=project_dir).returncode)

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -110,7 +110,7 @@ def main() -> None:
                 supported. You can run on your development machine or other CI providers using the
                 --platform argument. Check --help output for more information.
             '''), file=sys.stderr)
-            exit(2)
+            sys.exit(2)
         if sys.platform.startswith('linux'):
             platform = 'linux'
         elif sys.platform == 'darwin':
@@ -121,11 +121,11 @@ def main() -> None:
             print('cibuildwheel: Unable to detect platform from "sys.platform" in a CI environment. You can run '
                   'cibuildwheel using the --platform argument. Check --help output for more information.',
                   file=sys.stderr)
-            exit(2)
+            sys.exit(2)
 
     if platform not in PLATFORMS:
         print(f'cibuildwheel: Unsupported platform: {platform}', file=sys.stderr)
-        exit(2)
+        sys.exit(2)
 
     package_dir = Path(args.package_dir)
     output_dir = Path(args.output_dir)
@@ -158,7 +158,7 @@ def main() -> None:
     except (EnvironmentParseError, ValueError):
         print(f'cibuildwheel: Malformed environment option "{environment_config}"', file=sys.stderr)
         traceback.print_exc(None, sys.stderr)
-        exit(2)
+        sys.exit(2)
 
     if dependency_versions == 'pinned':
         dependency_constraints: Optional[DependencyConstraints] = DependencyConstraints.with_defaults()
@@ -183,7 +183,7 @@ def main() -> None:
     if not any((package_dir / name).exists()
                for name in ["setup.py", "setup.cfg", "pyproject.toml"]):
         print('cibuildwheel: Could not find setup.py, setup.cfg or pyproject.toml at root of package', file=sys.stderr)
-        exit(2)
+        sys.exit(2)
 
     if args.archs is not None:
         archs_config_str = args.archs
@@ -193,7 +193,7 @@ def main() -> None:
 
     if args.print_build_identifiers:
         print_build_identifiers(platform, build_selector, archs)
-        exit(0)
+        sys.exit(0)
 
     manylinux_images: Optional[Dict[str, str]] = None
     if platform == 'linux':
@@ -271,7 +271,7 @@ def detect_obsolete_options() -> None:
                 os.environ[alternative] = os.environ[deprecated]
             else:
                 print(f"Option '{alternative}' is not empty. Please unset '{deprecated}'")
-                exit(2)
+                sys.exit(2)
 
     # Check for deprecated identifiers in 'CIBW_BUILD' and 'CIBW_SKIP' options
     for option in ['CIBW_BUILD', 'CIBW_SKIP']:

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -58,7 +58,7 @@ def build(options: BuildOptions) -> None:
               'If you\'re building on Travis CI, add `services: [docker]` to your .travis.yml.'
               'If you\'re building on Circle CI in Linux, add a `setup_remote_docker` step to your .circleci/config.yml',
               file=sys.stderr)
-        exit(2)
+        sys.exit(2)
 
     assert options.manylinux_images is not None
     python_configurations = get_python_configurations(options.build_selector, options.architectures)
@@ -138,12 +138,12 @@ def build(options: BuildOptions) -> None:
                     which_python = docker.call(['which', 'python'], env=env, capture_output=True).strip()
                     if PurePath(which_python) != python_bin / 'python':
                         print("cibuildwheel: python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it.", file=sys.stderr)
-                        exit(1)
+                        sys.exit(1)
 
                     which_pip = docker.call(['which', 'pip'], env=env, capture_output=True).strip()
                     if PurePath(which_pip) != python_bin / 'pip':
                         print("cibuildwheel: pip available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert pip above it.", file=sys.stderr)
-                        exit(1)
+                        sys.exit(1)
 
                     if options.before_build:
                         log.step('Running before_build...')
@@ -233,7 +233,7 @@ def build(options: BuildOptions) -> None:
         except subprocess.CalledProcessError as error:
             log.error(f'Command {error.cmd} failed with code {error.returncode}. {error.stdout}')
             troubleshoot(options.package_dir, error)
-            exit(1)
+            sys.exit(1)
 
 
 def troubleshoot(package_dir: Path, error: Exception) -> None:

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -157,7 +157,7 @@ def setup_python(python_configuration: PythonConfiguration,
     which_python = subprocess.check_output(['which', 'python'], env=env, universal_newlines=True).strip()
     if which_python != '/tmp/cibw_bin/python':
         print("cibuildwheel: python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it.", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
 
     # install pip & wheel
     call(['python', get_pip_script, *dependency_constraint_flags], env=env, cwd="/tmp")
@@ -167,7 +167,7 @@ def setup_python(python_configuration: PythonConfiguration,
     which_pip = subprocess.check_output(['which', 'pip'], env=env, universal_newlines=True).strip()
     if which_pip != '/tmp/cibw_bin/pip':
         print("cibuildwheel: pip available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert pip above it.", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
 
     # Set MACOSX_DEPLOYMENT_TARGET to 10.9, if the user didn't set it.
     # CPython 3.5 defaults to 10.6, and pypy defaults to 10.7, causing
@@ -301,4 +301,4 @@ def build(options: BuildOptions) -> None:
             log.build_end()
     except subprocess.CalledProcessError as error:
         log.error(f'Command {error.cmd} failed with code {error.returncode}. {error.stdout}')
-        exit(1)
+        sys.exit(1)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -153,7 +153,7 @@ def setup_python(python_configuration: PythonConfiguration, dependency_constrain
     where_python = subprocess.check_output(['where', 'python'], env=env, universal_newlines=True).splitlines()[0].strip()
     if where_python != str(installation_path / 'python.exe'):
         print("cibuildwheel: python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it.", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
 
     # make sure pip is installed
     if not (installation_path / 'Scripts' / 'pip.exe').exists():
@@ -162,7 +162,7 @@ def setup_python(python_configuration: PythonConfiguration, dependency_constrain
     where_pip = subprocess.check_output(['where', 'pip'], env=env, universal_newlines=True).splitlines()[0].strip()
     if where_pip.strip() != str(installation_path / 'Scripts' / 'pip.exe'):
         print("cibuildwheel: pip available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert pip above it.", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
 
     log.step('Installing build tools...')
 
@@ -330,4 +330,4 @@ def build(options: BuildOptions) -> None:
             log.build_end()
     except subprocess.CalledProcessError as error:
         log.error(f'Command {error.cmd} failed with code {error.returncode}. {error.stdout}')
-        exit(1)
+        sys.exit(1)


### PR DESCRIPTION
Changes some raw uses of `exit()` to either `sys.exit` or `raise Exit` from click. Just a correctness fix (unless site.py is not loaded).
