### PR TITLE
fix: action still runs if setup-python is not called

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,18 @@ runs:
   using: composite
   steps:
 
+    # Use python3 on unix and python on windows. This is
+    # only important if a user forgets to run setup-python first.
+
     # This needs powershell-core because github.action path is a Windows-style
     # path on Windows.  Powershell-core understands both types of paths.
-    - run: python -m pip install ${{ github.action_path }}
+    - run: |
+        if ( $RUNNER_OS -eq 'Windows' ) {
+            python -m pip install ${{ github.action_path }}
+            python -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
+        }
+        else {
+            python3 -m pip install ${{ github.action_path }}
+            python3 -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
+        }
       shell: pwsh
-
-    - run: python -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
-      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -17,18 +17,12 @@ runs:
   using: composite
   steps:
 
-    # Use python3 on unix and python on windows. This is
-    # only important if a user forgets to run setup-python first.
-
     # This needs powershell-core because github.action path is a Windows-style
     # path on Windows.  Powershell-core understands both types of paths.
-    - run: |
-        if ( 'Windows' -eq "${{ runner.os }}" ) {
-            python -m pip install ${{ github.action_path }}
-            python -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
-        }
-        else {
-            python3 -m pip install ${{ github.action_path }}
-            python3 -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
-        }
+    - run: >
+        pipx run
+        --spec ${{ github.action_path }}
+        cibuildwheel
+        ${{ inputs.package-dir }}
+        --output-dir ${{ inputs.output-dir }}
       shell: pwsh

--- a/action.yml
+++ b/action.yml
@@ -19,27 +19,16 @@ runs:
 
     # Use python3 on unix and python on windows. This is
     # only important if a user forgets to run setup-python first.
-    - run: echo $RUNNER_OS
-      shell: bash
-
-    - run: echo "${{ runner.os }}"
-      shell: pwsh
 
     # This needs powershell-core because github.action path is a Windows-style
     # path on Windows.  Powershell-core understands both types of paths.
     - run: |
         if ( 'Windows' -eq "${{ runner.os }}" ) {
             python -m pip install ${{ github.action_path }}
+            python -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
         }
         else {
             python3 -m pip install ${{ github.action_path }}
+            python3 -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
         }
       shell: pwsh
-
-    - run: |
-        if [[ "$RUNNER_OS" == 'Windows' ]] ; then
-            python -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
-        else
-            python3 -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
-        fi
-      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -19,16 +19,27 @@ runs:
 
     # Use python3 on unix and python on windows. This is
     # only important if a user forgets to run setup-python first.
+    - run: echo $RUNNER_OS
+      shell: bash
+
+    - run: echo "${{ runner.os }}"
+      shell: pwsh
 
     # This needs powershell-core because github.action path is a Windows-style
     # path on Windows.  Powershell-core understands both types of paths.
     - run: |
-        if ( $RUNNER_OS -eq 'Windows' ) {
+        if ( 'Windows' -eq "${{ runner.os }}" ) {
             python -m pip install ${{ github.action_path }}
-            python -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
         }
         else {
             python3 -m pip install ${{ github.action_path }}
-            python3 -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
         }
       shell: pwsh
+
+    - run: |
+        if [[ "$RUNNER_OS" == 'Windows' ]] ; then
+            python -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
+        else
+            python3 -m cibuildwheel ${{ inputs.package-dir }} --output-dir ${{ inputs.output-dir }}
+        fi
+      shell: bash

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -116,7 +116,7 @@ If you use GitHub Actions for builds, you can use cibuildwheel as an action:
 uses: joerick/cibuildwheel@v1.7.4
 ```
 
-This is a composite step that just installs and runs cibuildwheel. You can set command-line options as `with:` parameters, and use `env:` as normal.
+This is a composite step that just runs cibuildwheel using pipx. You can set command-line options as `with:` parameters, and use `env:` as normal.
 
 Then, your `dependabot.yml` file could look like this:
 


### PR DESCRIPTION
This fixes the action so that it runs regardless of whether setup-python has been called first, on all runners except ubuntu 16.04. ~~on ubuntu-20.04 or macos-latest (it always worked on windows-latest). It does not fix ubuntu-18.04 (ubuntu-latest), but hopefully that will become 20.04 soon.~~

~~I'm not proposing we change the directions, just make it more likely to work if someone doesn't follow them.~~