### PR TITLE
fix: include host Python version in header

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,10 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
-  
+
   pipx_test:
-    runs-on: [ubuntu-18.04, ubuntu-20.04]
+    name: pipx-test
+    runs-on: ubuntu-18.04
     steps:
       - run: pipx run pytest `mktemp -d`
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,11 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
+  
+  pipx_test:
+    runs-on: [ubuntu-18.04, ubuntu-20.04]
+    steps:
+      - run: pipx run pytest `mktemp -d`
 
   test:
     name: Test cibuildwheel on ${{ matrix.os }}

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -291,7 +291,8 @@ def print_preamble(platform: str, build_options: BuildOptions) -> None:
         |___|_|___|___|_|_|___|_____|_|_|___|___|_|
         '''))
 
-    print(f'cibuildwheel version {cibuildwheel.__version__}\n')
+    python_version = ".".join(str(v) for v in sys.version_info[:3])
+    print(f'cibuildwheel {cibuildwheel.__version__} - hosted on Python {python_version}\n')
 
     print('Build options:')
     print(f'  platform: {platform!r}')


### PR DESCRIPTION
Adds the host Python version to the printout, would be useful for cases like #542 where you can't tell which Python this is running on, and might help us see if #508 is a good idea yet.

I've removed the word "version" from the cibuildwheel part to make it line up a bit better under the ASCII art.﻿ (Didn't realize it would line up _that_ well. :) )

```
     _ _       _ _   _       _           _
 ___|_| |_ _ _|_| |_| |_ _ _| |_ ___ ___| |
|  _| | . | | | | | . | | | |   | -_| -_| |
|___|_|___|___|_|_|___|_____|_|_|___|___|_|
 
cibuildwheel 1.7.4 - hosted on Python 3.9.1
```
