### PR TITLE
ci: add bot to remind users about docs builds if docs have changed

### DIFF
--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -1,0 +1,22 @@
+name: Reminder bot
+on:
+  pull_request:
+    types: [opened, edited]
+    paths:
+    - 'docs/*.md'
+    - 'README.md'
+
+jobs:
+  docs-reminder:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v3
+      with:
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `Thanks for updating the docs! See [latest output
+              here](https://cibuildwheel--${context.issue.number}.org.readthedocs.build/en/${context.issue.number}) for the latest docs build.`
+          })


### PR DESCRIPTION
@joerick, you might be interested. Have no idea if it actually works, based on the example here: https://github.com/actions/github-script#comment-on-an-issue .