### PR TITLE
fix: try to avoid error on CircleCI by avoiding explicit an use of /tmp directly

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -82,8 +82,10 @@ def install_cpython(version: str, url: str) -> Path:
             tmp_pkg = Path(tmp_name) / 'Python.pkg'
             # download the pkg
             download(url, tmp_pkg)
+            call(['ls', '-l', tmp_pkg])
             # install
             call(['sudo', 'installer', '-pkg', tmp_pkg, '-target', '/'])
+            raise RuntimeError("quiting")
             # patch open ssl
             if version == '3.5':
                 tmp_patch = Path(tmp_name) / 'python-patch.tar.gz'


### PR DESCRIPTION
Trying to see if this helps CircleCI.

Ideally we should refactor temporary directory handling, using the high level interface (TemporaryDirectory) and avoiding direclty using `/tmp` too much.﻿
