### PR TITLE
docs: cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,11 @@ env3?/
 # MyPy cache
 .mypy_cache/
 
+# Output cache for setup.py checker
 all_known_setup.yaml
+
+# mkdocs
+site/
+
+# Virtual environments
+venv*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   rev: 20.8b1
   hooks:
   - id: black
-    files: ^bin/update_pythons.py$
+    files: ^bin/update_pythons.py|setup.py$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.800

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,9 @@ mkdocs:
   configuration: mkdocs.yml
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .
       extra_requirements:
-        - dev
+        - docs

--- a/docs/options.md
+++ b/docs/options.md
@@ -356,27 +356,26 @@ CIBW_BEFORE_BUILD: "{package}/script/prepare_for_build.sh"
 ```
 
 !!! note
-    If you need dependencies installed for the build, we recommend using pyproject.toml. This is an example pyproject.toml file:
+    If you need dependencies installed for the build, we recommend using
+    `pyproject.toml`. This is an example `pyproject.toml` file:
 
         [build-system]
         requires = [
             "setuptools>=42",
             "wheel",
             "Cython",
-            "numpy==1.11.3; python_version<='3.6'",
-            "numpy==1.14.5; python_version=='3.7'",
-            "numpy==1.17.3; python_version=='3.8'",
-            "numpy==1.19.4; python_version>='3.9'",
+            "numpy==1.13.3; python_version<'3.5'",
+            "oldest-supported-numpy; python_version>='3.5'",
         ]
 
         build-backend = "setuptools.build_meta"
 
-    This [PEP 517][]/[PEP 518][] style build allows you to completely control the
-    build environment in cibuildwheel, [PyPA-build][], and pip, doesn't force
-    downstream users to install anything they don't need, and lets you do more
-    complex pinning (Cython, for example, requires a wheel to be built with an
-    equal or earlier version of NumPy; pinning in this way is the only way to
-    ensure your module works on all available NumPy versions).
+    This [PEP 517][]/[PEP 518][] style build allows you to completely control
+    the build environment in cibuildwheel, [PyPA-build][], and pip, doesn't
+    force downstream users to install anything they don't need, and lets you do
+    more complex pinning (Cython, for example, requires a wheel to be built
+    with an equal or earlier version of NumPy; pinning in this way is the only
+    way to ensure your module works on all available NumPy versions).
 
     [PyPA-build]: https://pypa-build.readthedocs.io/en/latest/
     [PEP 517]: https://www.python.org/dev/peps/pep-0517/

--- a/examples/github-deploy.yml
+++ b/examples/github-deploy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:
       - uses: actions/checkout@v2

--- a/examples/github-minimal.yml
+++ b/examples/github-minimal.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:
       - uses: actions/checkout@v2

--- a/examples/github-with-qemu.yml
+++ b/examples/github-with-qemu.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:
       - uses: actions/checkout@v2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
--e .[dev]
+-e .[dev,docs]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,21 +39,29 @@ install_requires =
 cibuildwheel = resources/*
 
 [options.extras_require]
-dev =
-    click
+docs =
     mkdocs-include-markdown-plugin==2.1.1
     mkdocs==1.0.4
+    pymdown-extensions
+test =
+    jinja2
+    pytest
+    pytest-timeout
+dev =
+    click
+    ghapi
+    jinja2
+    mypy>=0.800
+    packaging>=20.8
     pip-tools
     pygithub
-    ghapi
-    pymdown-extensions
-    pytest>=4
     pytest-timeout
+    pytest>=4
     pyyaml
     requests
-    typing-extensions
+    requests
     rich>=9.6
-    mypy>=0.800
+    typing-extensions
 
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,31 +38,6 @@ install_requires =
 [options.package_data]
 cibuildwheel = resources/*
 
-[options.extras_require]
-docs =
-    mkdocs-include-markdown-plugin==2.1.1
-    mkdocs==1.0.4
-    pymdown-extensions
-test =
-    jinja2
-    pytest
-    pytest-timeout
-dev =
-    click
-    ghapi
-    jinja2
-    mypy>=0.800
-    packaging>=20.8
-    pip-tools
-    pygithub
-    pytest-timeout
-    pytest>=4
-    pyyaml
-    requests
-    requests
-    rich>=9.6
-    typing-extensions
-
 [options.packages.find]
 include =
     cibuildwheel

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,31 @@
 from setuptools import setup
 
-setup()
+extras = {
+    "docs": [
+        "mkdocs-include-markdown-plugin==2.1.1",
+        "mkdocs==1.0.4",
+        "pymdown-extensions",
+    ],
+    "test": [
+        "jinja2",
+        "pytest>=4",
+        "pytest-timeout",
+    ],
+    "dev": [
+        "click",
+        "ghapi",
+        "mypy>=0.800",
+        "packaging>=20.8",
+        "pip-tools",
+        "pygithub",
+        "pyyaml",
+        "requests",
+        "rich>=9.6",
+        "typing-extensions",
+    ],
+}
+
+extras["all"] = sum(extras.values(), [])
+extras["dev"] += extras["test"]
+
+setup(extras_require=extras)


### PR DESCRIPTION
Adding three things (one commit each):

* Support for `[docs]` and `[test]` extras, allowing these to be installed individually. Dev no longer includes the docs requirements (but the requirements-dev file does both for you, just like before). Simplifies RtD build a little bit. Bumped the pinned versions of docs requirements. Edit: `[test]` not `[tests]`, more common (checked Pandas).
* Bump to showing the 20.04 images, since the default should be changing soon. (GHA only, not sure about Azure or others)
* ~~Support nested markdown in other constructs. @joerick I think there might be one other place where this was needed?~~ Removed for now, might be ruining styling