### PR TITLE
feat: print new files after building

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -281,6 +281,8 @@ def main() -> None:
     if not output_dir.exists():
         output_dir.mkdir(parents=True)
 
+    existing_contents = set(output_dir.iterdir())
+
     if platform == 'linux':
         cibuildwheel.linux.build(build_options)
     elif platform == 'windows':
@@ -289,6 +291,10 @@ def main() -> None:
         cibuildwheel.macos.build(build_options)
     else:
         assert_never(platform)
+
+    final_contents = set(output_dir.iterdir())
+    new_contents = final_contents - existing_contents
+    print("Produced wheels:", *sorted(f.name for f in new_contents))
 
 
 def detect_obsolete_options() -> None:

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -282,7 +282,7 @@ def main() -> None:
     if not output_dir.exists():
         output_dir.mkdir(parents=True)
 
-    with cibuildwheel.util.print_new_wheels("{n} wheels produced:", output_dir):
+    with cibuildwheel.util.print_new_wheels("{n} wheels produced in {m:.0f} minutes:", output_dir):
         if platform == 'linux':
             cibuildwheel.linux.build(build_options)
         elif platform == 'windows':

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -1,18 +1,18 @@
 import argparse
-import contextlib
 import os
 import sys
 import textwrap
 import traceback
 from configparser import ConfigParser
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Set, Union, overload
+from typing import Dict, List, Optional, Set, Union, overload
 
 from packaging.specifiers import SpecifierSet
 
 import cibuildwheel
 import cibuildwheel.linux
 import cibuildwheel.macos
+import cibuildwheel.util
 import cibuildwheel.windows
 from cibuildwheel.architecture import Architecture, allowed_architectures_check
 from cibuildwheel.environment import EnvironmentParseError, parse_environment
@@ -282,7 +282,7 @@ def main() -> None:
     if not output_dir.exists():
         output_dir.mkdir(parents=True)
 
-    with print_new_wheels("{n} wheels produced:", output_dir):
+    with cibuildwheel.util.print_new_wheels("{n} wheels produced:", output_dir):
         if platform == 'linux':
             cibuildwheel.linux.build(build_options)
         elif platform == 'windows':
@@ -314,18 +314,6 @@ def detect_obsolete_options() -> None:
             if option in os.environ and deprecated in os.environ[option]:
                 print(f"Build identifiers with '{deprecated}' have been deprecated. Replacing all occurences of '{deprecated}' with '{alternative}' in the option '{option}'")
                 os.environ[option] = os.environ[option].replace(deprecated, alternative)
-
-
-@contextlib.contextmanager
-def print_new_wheels(msg: str, output_dir: Path) -> Iterator[None]:
-    existing_contents = set(output_dir.iterdir())
-    try:
-        yield
-    finally:
-        final_contents = set(output_dir.iterdir())
-        new_contents = final_contents - existing_contents
-        n = len(new_contents)
-        print(msg.format(n=n), *sorted(f"  {f.name}" for f in new_contents), sep="\n")
 
 
 def print_preamble(platform: str, build_options: BuildOptions) -> None:

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -1,3 +1,4 @@
+import contextlib
 import fnmatch
 import itertools
 import os
@@ -8,7 +9,7 @@ import urllib.request
 from enum import Enum
 from pathlib import Path
 from time import sleep
-from typing import Dict, List, NamedTuple, Optional, Set
+from typing import Dict, Iterator, List, NamedTuple, Optional, Set
 
 import bracex
 import certifi
@@ -251,3 +252,15 @@ def unwrap(text: str) -> str:
     text = text.strip()
     # remove consecutive whitespace
     return re.sub(r'\s+', ' ', text)
+
+
+@contextlib.contextmanager
+def print_new_wheels(msg: str, output_dir: Path) -> Iterator[None]:
+    existing_contents = set(output_dir.iterdir())
+    try:
+        yield
+    finally:
+        final_contents = set(output_dir.iterdir())
+        new_contents = final_contents - existing_contents
+        n = len(new_contents)
+        print(msg.format(n=n), *sorted(f"  {f.name}" for f in new_contents), sep="\n")

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -5,6 +5,7 @@ import os
 import re
 import ssl
 import textwrap
+import time
 import urllib.request
 from enum import Enum
 from pathlib import Path
@@ -256,9 +257,19 @@ def unwrap(text: str) -> str:
 
 @contextlib.contextmanager
 def print_new_wheels(msg: str, output_dir: Path) -> Iterator[None]:
+    '''
+    Prints the new items in a directory upon exiting. The message to display
+    can include {n} for number of wheels, {s} for total number of seconds,
+    and/or {m} for total number of minutes. Does not print anything if this
+    exits via exception.
+    '''
+
+    start_time = time.time()
     existing_contents = set(output_dir.iterdir())
     yield
     final_contents = set(output_dir.iterdir())
     new_contents = final_contents - existing_contents
     n = len(new_contents)
-    print(msg.format(n=n), *sorted(f"  {f.name}" for f in new_contents), sep="\n")
+    s = time.time() - start_time
+    m = s / 60
+    print(msg.format(n=n, s=s, m=m), *sorted(f"  {f.name}" for f in new_contents), sep="\n")

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -257,10 +257,8 @@ def unwrap(text: str) -> str:
 @contextlib.contextmanager
 def print_new_wheels(msg: str, output_dir: Path) -> Iterator[None]:
     existing_contents = set(output_dir.iterdir())
-    try:
-        yield
-    finally:
-        final_contents = set(output_dir.iterdir())
-        new_contents = final_contents - existing_contents
-        n = len(new_contents)
-        print(msg.format(n=n), *sorted(f"  {f.name}" for f in new_contents), sep="\n")
+    yield
+    final_contents = set(output_dir.iterdir())
+    new_contents = final_contents - existing_contents
+    n = len(new_contents)
+    print(msg.format(n=n), *sorted(f"  {f.name}" for f in new_contents), sep="\n")

--- a/unit_test/main_tests/conftest.py
+++ b/unit_test/main_tests/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import platform as platform_module
 import subprocess
 import sys
@@ -52,14 +53,19 @@ def fake_package_dir(monkeypatch):
         else:
             return real_path_exists(path)
 
-    def mock_iterdir(path):
-        return {}
-
     args = ['cibuildwheel', str(MOCK_PACKAGE_DIR)]
     monkeypatch.setattr(Path, 'exists', mock_path_exists)
-    monkeypatch.setattr(Path, 'iterdir', mock_iterdir)
     monkeypatch.setattr(sys, 'argv', args)
     return args
+
+
+@pytest.fixture(autouse=True)
+def disable_print_wheels(monkeypatch):
+    @contextlib.contextmanager
+    def empty_cm(*args, **kwargs):
+        yield
+
+    monkeypatch.setattr(util, 'print_new_wheels', empty_cm)
 
 
 @pytest.fixture

--- a/unit_test/main_tests/conftest.py
+++ b/unit_test/main_tests/conftest.py
@@ -52,8 +52,12 @@ def fake_package_dir(monkeypatch):
         else:
             return real_path_exists(path)
 
+    def mock_iterdir(path):
+        return {}
+
     args = ['cibuildwheel', str(MOCK_PACKAGE_DIR)]
     monkeypatch.setattr(Path, 'exists', mock_path_exists)
+    monkeypatch.setattr(Path, 'iterdir', mock_iterdir)
     monkeypatch.setattr(sys, 'argv', args)
     return args
 

--- a/unit_test/main_tests/main_requires_python_test.py
+++ b/unit_test/main_tests/main_requires_python_test.py
@@ -1,5 +1,6 @@
 import sys
 import textwrap
+from pathlib import Path
 
 import pytest
 from packaging.specifiers import SpecifierSet
@@ -18,7 +19,11 @@ def fake_package_dir(monkeypatch, tmp_path):
 
     local_path.joinpath("setup.py").touch()
 
+    def mock_iterdir(path):
+        return {}
+
     monkeypatch.setattr(sys, 'argv', ['cibuildwheel', str(local_path)])
+    monkeypatch.setattr(Path, 'iterdir', mock_iterdir)
 
     return local_path
 

--- a/unit_test/main_tests/main_requires_python_test.py
+++ b/unit_test/main_tests/main_requires_python_test.py
@@ -1,6 +1,5 @@
 import sys
 import textwrap
-from pathlib import Path
 
 import pytest
 from packaging.specifiers import SpecifierSet
@@ -19,11 +18,7 @@ def fake_package_dir(monkeypatch, tmp_path):
 
     local_path.joinpath("setup.py").touch()
 
-    def mock_iterdir(path):
-        return {}
-
     monkeypatch.setattr(sys, 'argv', ['cibuildwheel', str(local_path)])
-    monkeypatch.setattr(Path, 'iterdir', mock_iterdir)
 
     return local_path
 

--- a/unit_test/test_wheel_print.py
+++ b/unit_test/test_wheel_print.py
@@ -1,0 +1,35 @@
+import pytest
+
+from cibuildwheel.util import print_new_wheels
+
+
+def test_printout_wheels(tmp_path, capsys):
+    tmp_path.joinpath("example.0").touch()
+    with print_new_wheels("TEST_MSG: {n}", tmp_path):
+        tmp_path.joinpath("example.1").touch()
+        tmp_path.joinpath("example.2").touch()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    assert "example.0" not in captured.out
+    assert "example.1\n" in captured.out
+    assert "example.2\n" in captured.out
+    assert "TEST_MSG:" in captured.out
+    assert "TEST_MSG: 2\n" in captured.out
+
+
+def test_no_printout_on_error(tmp_path, capsys):
+    tmp_path.joinpath("example.0").touch()
+    with pytest.raises(RuntimeError):
+        with print_new_wheels("TEST_MSG: {n}", tmp_path):
+            tmp_path.joinpath("example.1").touch()
+            raise RuntimeError()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    assert "example.0" not in captured.out
+    assert "example.1" not in captured.out
+    assert "example.2" not in captured.out
+    assert "TEST_MSG:" not in captured.out


### PR DESCRIPTION
This adds a printout after cibuildwheel runs to list exactly what changes. Serves as a good way to check to see exactly what built, and should show if any (un)expected extra files show up.

Closes #566 