### PR TITLE
docs: support tabs

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -89,3 +89,42 @@ h1, h2, h3, h4, h5, h6 {
 
 /* import font awesome 4 for icons */
 @import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css);
+
+
+/* Tabs */
+
+/* Style the tab */
+.tab {
+  overflow: hidden;
+  border: 1px solid #ccc;
+  background-color: #f1f1f1;
+}
+
+/* Style the buttons that are used to open the tab content */
+.tab button {
+  background-color: inherit;
+  float: left;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  padding: 14px 16px;
+  transition: 0.3s;
+}
+
+/* Change background color of buttons on hover */
+.tab button:hover {
+  background-color: #ddd;
+}
+
+/* Create an active/current tablink class */
+.tab button.active {
+  background-color: #ccc;
+}
+
+/* Style the tab content */
+.tabcontent {
+  display: none;
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  border-top: none;
+}

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -94,37 +94,54 @@ h1, h2, h3, h4, h5, h6 {
 /* Tabs */
 
 /* Style the tab */
-.tab {
-  overflow: hidden;
-  border: 1px solid #ccc;
-  background-color: #f1f1f1;
+.tabs {
+  margin-bottom: 1em;
+  -webkit-font-smoothing: antialiased;
+}
+
+.tabs-header {
+  background-color: white;
+  display: flex;
+  justify-content: flex-start;
+  border-bottom: 2px solid #ccc;
 }
 
 /* Style the buttons that are used to open the tab content */
-.tab button {
-  background-color: inherit;
-  float: left;
+.tabs-header button {
+  background-color: transparent;
   border: none;
   outline: none;
   cursor: pointer;
-  padding: 14px 16px;
-  transition: 0.3s;
+  color: inherit;
+  font: inherit;
+  font-size: 0.9em;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-bottom: 2px solid transparent;
+
+  /* put the border on top of the parent border */
+  margin-bottom: -2px;
+}
+
+.tabs-header button:focus-visible {
+  /* preserve an outline for accesibility purposes */
+  outline: 1px solid currentColor;
 }
 
 /* Change background color of buttons on hover */
-.tab button:hover {
-  background-color: #ddd;
+.tabs-header button:hover {
+  background-color: rgba(0, 0, 0, 0.02);
 }
 
 /* Create an active/current tablink class */
-.tab button.active {
-  background-color: #ccc;
+.tabs-header button.active {
+  color: #4086bd;
+  border-bottom-color: currentColor;
 }
 
 /* Style the tab content */
-.tabcontent {
-  display: none;
-  padding: 6px 12px;
-  border: 1px solid #ccc;
-  border-top: none;
+.tabs-content {
+  background-color: #f1f6fa;
+  padding: 1px 1em;
+  padding-top: 0.8em;
 }

--- a/docs/extra.js
+++ b/docs/extra.js
@@ -1,4 +1,49 @@
-
+// add classes for code-block-filename styling
 $('.rst-content pre')
     .prev('blockquote')
     .addClass('code-block-filename');
+
+var i=0
+
+// convert tab admonition to tabs
+while (true) {
+  const firstTab = $('.rst-content .admonition.tab').first()
+  if (firstTab.length == 0) break;
+
+  const otherTabs = firstTab.nextUntil(':not(.admonition.tab)');
+  const allTabs = $($.merge($.merge([], firstTab), otherTabs));
+
+  const tabContainer = $('<div>').addClass('tabs');
+  const headerContainer = $('<div>').addClass('tabs-header');
+  const contentContainer = $('<div>').addClass('tabs-content');
+  console.log(allTabs)
+
+  tabContainer.insertBefore(firstTab);
+  tabContainer.append(headerContainer, contentContainer)
+
+  const selectTab = function (index) {
+    headerContainer.children().removeClass('active')
+    headerContainer.children().eq(index).addClass('active')
+    contentContainer.children().hide()
+    contentContainer.children().eq(index).show()
+  }
+
+  allTabs.each(function (i, el) {
+    const $el = $(el)
+    const titleElement = $el.children('.admonition-title')
+    const title = titleElement.text()
+    const button = $('<button>').text(title)
+    button.click(function () {
+      selectTab(i)
+    })
+    headerContainer.append(button)
+
+    titleElement.remove()
+    $el.removeClass('admonition')
+    contentContainer.append($el)
+  })
+
+  selectTab(0)
+
+  if (i++ > 1000) throw 'too many iterations'
+}

--- a/docs/extra.js
+++ b/docs/extra.js
@@ -3,7 +3,7 @@ $('.rst-content pre')
     .prev('blockquote')
     .addClass('code-block-filename');
 
-var i=0
+var tabConversionIterations = 0
 
 // convert tab admonition to tabs
 while (true) {
@@ -16,7 +16,6 @@ while (true) {
   const tabContainer = $('<div>').addClass('tabs');
   const headerContainer = $('<div>').addClass('tabs-header');
   const contentContainer = $('<div>').addClass('tabs-content');
-  console.log(allTabs)
 
   tabContainer.insertBefore(firstTab);
   tabContainer.append(headerContainer, contentContainer)
@@ -28,13 +27,13 @@ while (true) {
     contentContainer.children().eq(index).show()
   }
 
-  allTabs.each(function (i, el) {
+  allTabs.each(function (tabI, el) {
     const $el = $(el)
     const titleElement = $el.children('.admonition-title')
     const title = titleElement.text()
     const button = $('<button>').text(title)
     button.click(function () {
-      selectTab(i)
+      selectTab(tabI)
     })
     headerContainer.append(button)
 
@@ -45,5 +44,6 @@ while (true) {
 
   selectTab(0)
 
-  if (i++ > 1000) throw 'too many iterations'
+  // this will catch infinite loops which can occur when editing the above
+  if (tabConversionIterations++ > 1000) throw 'too many iterations'
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -105,6 +105,7 @@ Actions. Once QEMU is set up and registered, you just need to set the
 Linux), and the other architectures are emulated automatically.
 
 > .github/workflows/build.yml
+
 ```yaml
 {% include "../examples/github-with-qemu.yml" %}
 ```
@@ -130,6 +131,7 @@ Hopefully, this is a temporary situation. Once we have widely available Apple Si
 Here's an example GitHub Actions workflow with a job that builds for Apple Silicon:
 
 > .github/workflows/build_macos.yml
+
 ```yml
 {% include "../examples/github-apple-silicon.yml" %}
 ```

--- a/docs/options.md
+++ b/docs/options.md
@@ -10,49 +10,72 @@ your CI config.
 For example, to configure cibuildwheel to run tests, add the following YAML to
 your CI config file:
 
-> .travis.yml ([docs](https://docs.travis-ci.com/user/environment-variables/))
 
-```yaml
-env:
-  global:
-    - CIBW_TEST_REQUIRES=pytest
-    - CIBW_TEST_COMMAND="pytest {project}/tests"
-```
+!!! tab "GitHub Actions"
 
-> appveyor.yml ([docs](https://www.appveyor.com/docs/build-configuration/#environment-variables))
+    > .github/workflows/*.yml ([docs](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables)) (can be global, in job, or in step)
 
-```yaml
-environment:
-  global:
-    CIBW_TEST_REQUIRES: pytest
-    CIBW_TEST_COMMAND: "pytest {project}\\tests"
-```
-
-> .circleci/config.yml ([docs](https://circleci.com/docs/2.0/configuration-reference/#environment))
-
-```yaml
-jobs:
-  job_name:
-    environment:
+    ```yaml
+    env:
       CIBW_TEST_REQUIRES: pytest
       CIBW_TEST_COMMAND: "pytest {project}/tests"
-```
+    ```
 
-> azure-pipelines.yml ([docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables))
+!!! tab "Azure Pipelines"
 
-```yaml
-variables:
-  CIBW_TEST_REQUIRES: pytest
-  CIBW_TEST_COMMAND: "pytest {project}/tests"
-```
+    > azure-pipelines.yml ([docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables))
 
-> .github/workflows/*.yml ([docs](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables)) (can be global, in job, or in step)
+    ```yaml
+    variables:
+      CIBW_TEST_REQUIRES: pytest
+      CIBW_TEST_COMMAND: "pytest {project}/tests"
+    ```
 
-```yaml
-env:
-  CIBW_TEST_REQUIRES: pytest
-  CIBW_TEST_COMMAND: "pytest {project}/tests"
-```
+!!! tab "Travis CI"
+
+    > .travis.yml ([docs](https://docs.travis-ci.com/user/environment-variables/))
+
+    ```yaml
+    env:
+      global:
+        - CIBW_TEST_REQUIRES=pytest
+        - CIBW_TEST_COMMAND="pytest {project}/tests"
+    ```
+
+!!! tab "AppVeyor"
+
+    > appveyor.yml ([docs](https://www.appveyor.com/docs/build-configuration/#environment-variables))
+
+    ```yaml
+    environment:
+      global:
+        CIBW_TEST_REQUIRES: pytest
+        CIBW_TEST_COMMAND: "pytest {project}\\tests"
+    ```
+
+!!! tab "CircleCI"
+
+    > .circleci/config.yml ([docs](https://circleci.com/docs/2.0/configuration-reference/#environment))
+
+    ```yaml
+    jobs:
+      job_name:
+        environment:
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: "pytest {project}/tests"
+    ```
+
+!!! tab "Gitlab CI"
+
+    > .gitlab-ci.yml ([docs](https://docs.gitlab.com/ee/ci/variables/README.html#create-a-custom-variable-in-gitlab-ciyml))
+
+    ```yaml
+    linux:
+      variables:
+        CIBW_TEST_REQUIRES: pytest
+        CIBW_TEST_COMMAND: "pytest {project}/tests"
+    ```
+
 
 
 ## Build selection

--- a/docs/options.md
+++ b/docs/options.md
@@ -11,6 +11,7 @@ For example, to configure cibuildwheel to run tests, add the following YAML to
 your CI config file:
 
 > .travis.yml ([docs](https://docs.travis-ci.com/user/environment-variables/))
+
 ```yaml
 env:
   global:
@@ -19,6 +20,7 @@ env:
 ```
 
 > appveyor.yml ([docs](https://www.appveyor.com/docs/build-configuration/#environment-variables))
+
 ```yaml
 environment:
   global:
@@ -27,6 +29,7 @@ environment:
 ```
 
 > .circleci/config.yml ([docs](https://circleci.com/docs/2.0/configuration-reference/#environment))
+
 ```yaml
 jobs:
   job_name:
@@ -36,6 +39,7 @@ jobs:
 ```
 
 > azure-pipelines.yml ([docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables))
+
 ```yaml
 variables:
   CIBW_TEST_REQUIRES: pytest
@@ -43,6 +47,7 @@ variables:
 ```
 
 > .github/workflows/*.yml ([docs](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables)) (can be global, in job, or in step)
+
 ```yaml
 env:
   CIBW_TEST_REQUIRES: pytest

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,7 +14,7 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
     > .github/workflows/build_wheels.yml
 
     ```yaml
-    {% include "../examples/github-minimal.yml" preserve_includer_indent=true %}
+    {% include "../examples/github-minimal.yml" %}
     ```
 
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,31 +14,9 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
     > .github/workflows/build_wheels.yml
 
     ```yaml
-    name: Build
-
-    on: [push, pull_request]
-
-    jobs:
-      build_wheels:
-        name: Build wheels on ${{ matrix.os }}
-        runs-on: ${{ matrix.os }}
-        strategy:
-          matrix:
-            os: [ubuntu-20.04, windows-2019, macos-10.15]
-
-        steps:
-          - uses: actions/checkout@v2
-
-          - name: Install Visual C++ for Python 2.7
-            if: runner.os == 'Windows'
-            run: choco install vcpython27 -f -y
-
-          - uses: joerick/cibuildwheel@1.8.0
-
-          - uses: actions/upload-artifact@v2
-            with:
-              path: ./wheelhouse/*.whl
+    {% include "../examples/github-minimal.yml" preserve_includer_indent=true %}
     ```
+
 
     You can use `env:` with the action just like you would with `run:`; you can
     also use `with:` to set the command line options: `package-dir: .` and
@@ -88,7 +66,37 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
     > .github/workflows/build_wheels.yml
 
     ```yaml
-    {% include "../examples/github-minimal.yml" preserve_includer_indent=true %}
+    name: Build
+
+    on: [push, pull_request]
+
+    jobs:
+      build_wheels:
+        name: Build wheels on ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+        steps:
+          - uses: actions/checkout@v2
+
+          # Used to host cibuildwheel
+          - uses: actions/setup-python@v2
+
+          - name: Install cibuildwheel
+            run: python -m pip install cibuildwheel==1.9.0
+
+          - name: Install Visual C++ for Python 2.7
+            if: runner.os == 'Windows'
+            run: choco install vcpython27 -f -y
+
+          - name: Build wheels
+            run: python -m cibuildwheel --output-dir wheelhouse
+
+          - uses: actions/upload-artifact@v2
+            with:
+              path: ./wheelhouse/*.whl
     ```
 
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,7 +4,7 @@ title: 'Setup'
 
 # GitHub Actions [linux/mac/windows] {: #github-actions}
 
-To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/workflows/build.yml` file in your repo.
+To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/workflows/build_wheels.yml` file in your repo.
 
 
 <div class="tab">
@@ -18,7 +18,8 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
 
 This is the most generic form.
 
-> build.yml
+> .github/workflows/build_wheels.yml
+
 ```yaml
 {% include "../examples/github-minimal.yml" %}
 ```
@@ -26,7 +27,8 @@ This is the most generic form.
 <div id="gha-pipx" class="tabcontent" markdown="1">
 The GitHub Actions runners have pipx installed, so you can simplify this:
 
-> build.yml
+> .github/workflows/build_wheels.yml
+
 ```yaml
 name: Build
 
@@ -58,7 +60,8 @@ jobs:
 <div id="gha-action" class="tabcontent" markdown="1">
 You can instead use the action, which enables easier auto updating via GitHub's Dependabot.
 
-> build.yml
+> .github/workflows/build_wheels.yml
+
 ```yaml
 name: Build
 
@@ -100,6 +103,7 @@ You can also use cibuildwheel directly as an action with `uses: joerick/cibuildw
 To build Linux, Mac, and Windows wheels on Azure Pipelines, create a `azure-pipelines.yml` file in your repo.
 
 > azure-pipelines.yml
+
 ```yaml
 {% include "../examples/azure-pipelines-minimal.yml" %}
 ```
@@ -116,6 +120,7 @@ Wheels will be stored for you and available through the Pipelines interface. For
 To build Linux, Mac, and Windows wheels on Travis CI, create a `.travis.yml` file in your repo.
 
 > .travis.yml
+
 ```yaml
 {% include "../examples/travis-ci-minimal.yml" %}
 ```
@@ -133,6 +138,7 @@ Then setup a deployment method by following the [Travis CI deployment docs](http
 To build Linux and Mac wheels on CircleCI, create a `.circleci/config.yml` file in your repo,
 
 > .circleci/config.yml
+
 ```yaml
 {% include "../examples/circleci-minimal.yml" %}
 ```
@@ -149,6 +155,7 @@ CircleCI will store the built wheels for you - you can access them from the proj
 To build Linux wheels on Gitlab CI, create a `.gitlab-ci.yml` file in your repo,
 
 > .gitlab-ci.yml
+
 ```yaml
 {% include "../examples/gitlab-minimal.yml" %}
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -134,6 +134,22 @@ Then setup a deployment method by following the [Travis CI deployment docs](http
 
 [`examples/travis-ci-deploy.yml`](https://github.com/joerick/cibuildwheel/blob/master/examples/travis-ci-deploy.yml) extends this minimal example with a demonstration of how to automatically upload the built wheels to PyPI.
 
+# AppVeyor [linux/mac/windows] {: #appveyor}
+
+To build Linux, Mac, and Windows wheels on AppVeyor, create an `appveyor.yml` file in your repo.
+
+> appveyor.yml
+
+```yaml
+{% include "../examples/appveyor-minimal.yml" %}
+```
+
+Commit this file, enable building of your repo on AppVeyor, and push.
+
+AppVeyor will store the built wheels for you - you can access them from the project console. Alternatively, you may want to store them in the same place as the Travis CI build. See [AppVeyor deployment docs](https://www.appveyor.com/docs/deployment/) for more info, or see [Delivering to PyPI](deliver-to-pypi.md) below.
+
+For more info on this config file, check out the [docs](https://www.appveyor.com/docs/).
+
 # CircleCI [linux/mac] {: #circleci}
 
 To build Linux and Mac wheels on CircleCI, create a `.circleci/config.yml` file in your repo,
@@ -164,22 +180,6 @@ To build Linux wheels on Gitlab CI, create a `.gitlab-ci.yml` file in your repo,
 Commit this file, and push to Gitlab. The pipeline should start automatically.
 
 Gitlab will store the built wheels for you - you can access them from the Pipelines view. Check out the Gitlab [docs](https://docs.gitlab.com/ee/ci/yaml/) for more info on this config file.
-
-# AppVeyor [linux/mac/windows] {: #appveyor}
-
-To build Linux, Mac, and Windows wheels on AppVeyor, create an `appveyor.yml` file in your repo.
-
-> appveyor.yml
-
-```yaml
-{% include "../examples/appveyor-minimal.yml" %}
-```
-
-Commit this file, enable building of your repo on AppVeyor, and push.
-
-AppVeyor will store the built wheels for you - you can access them from the project console. Alternatively, you may want to store them in the same place as the Travis CI build. See [AppVeyor deployment docs](https://www.appveyor.com/docs/deployment/) for more info, or see [Delivering to PyPI](deliver-to-pypi.md) below.
-
-For more info on this config file, check out the [docs](https://www.appveyor.com/docs/).
 
 > ⚠️ Got an error? Check the [FAQ](faq.md).
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,89 +6,79 @@ title: 'Setup'
 
 To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/workflows/build_wheels.yml` file in your repo.
 
+!!! tab "Generic"
+    This is the most generic form.
 
-<div class="tab">
-  <button class="tablinks" id="defaultOpen" onclick="openGHA(event, 'gha-generic')">Generic</button>
-  <button class="tablinks" onclick="openGHA(event, 'gha-pipx')">Pipx</button>
-  <button class="tablinks" onclick="openGHA(event, 'gha-action')">Action</button>
-</div>
+    > .github/workflows/build_wheels.yml
 
+    ```yaml
+    {% include "../examples/github-minimal.yml" preserve_includer_indent=true %}
+    ```
 
-<div id="gha-generic" class="tabcontent" markdown="1">
+!!! tab "pipx"
+    The GitHub Actions runners have pipx installed, so you can simplify this:
 
-This is the most generic form.
+    > .github/workflows/build_wheels.yml
 
-> .github/workflows/build_wheels.yml
+    ```yaml
+    name: Build
 
-```yaml
-{% include "../examples/github-minimal.yml" %}
-```
-</div>
-<div id="gha-pipx" class="tabcontent" markdown="1">
-The GitHub Actions runners have pipx installed, so you can simplify this:
+    on: [push, pull_request]
 
-> .github/workflows/build_wheels.yml
+    jobs:
+      build_wheels:
+        name: Build wheels on ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [ubuntu-18.04, windows-2019, macos-10.15]
 
-```yaml
-name: Build
+        steps:
+          - uses: actions/checkout@v2
 
-on: [push, pull_request]
+          - name: Install Visual C++ for Python 2.7
+            if: runner.os == 'Windows'
+            run: choco install vcpython27 -f -y
 
-jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+          - name: Build wheels
+            run: pix run cibuildwheel==1.8.0
 
-    steps:
-      - uses: actions/checkout@v2
+          - uses: actions/upload-artifact@v2
+            with:
+              path: ./wheelhouse/*.whl
+    ```
 
-      - name: Install Visual C++ for Python 2.7
-        if: runner.os == 'Windows'
-        run: choco install vcpython27 -f -y
+!!! tab "Action"
+    You can instead use the action, which enables easier auto updating via GitHub's Dependabot.
 
-      - name: Build wheels
-        run: pix run cibuildwheel==1.8.0
+    > .github/workflows/build_wheels.yml
 
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
-```
-</div>
-<div id="gha-action" class="tabcontent" markdown="1">
-You can instead use the action, which enables easier auto updating via GitHub's Dependabot.
+    ```yaml
+    name: Build
 
-> .github/workflows/build_wheels.yml
+    on: [push, pull_request]
 
-```yaml
-name: Build
+    jobs:
+      build_wheels:
+        name: Build wheels on ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [ubuntu-18.04, windows-2019, macos-10.15]
 
-on: [push, pull_request]
+        steps:
+          - uses: actions/checkout@v2
 
-jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+          - name: Install Visual C++ for Python 2.7
+            if: runner.os == 'Windows'
+            run: choco install vcpython27 -f -y
 
-    steps:
-      - uses: actions/checkout@v2
+          - uses: joerick/cibuildwheel@1.8.0
 
-      - name: Install Visual C++ for Python 2.7
-        if: runner.os == 'Windows'
-        run: choco install vcpython27 -f -y
-
-      - uses: joerick/cibuildwheel@1.8.0
-
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
-```
-</div>
+          - uses: actions/upload-artifact@v2
+            with:
+              path: ./wheelhouse/*.whl
+    ```
 
 Commit this file, and push to GitHub - either to your default branch, or to a PR branch. The build should start automatically.
 
@@ -211,26 +201,4 @@ For more info on this config file, check out the [docs](https://www.appveyor.com
       }
     });
   });
-
-  function openGHA(evt, ghaName) {
-    var i, tabcontent, tablinks;
-
-    // Get all elements with class="tabcontent" and hide them
-    tabcontent = document.getElementsByClassName("tabcontent");
-    for (i = 0; i < tabcontent.length; i++) {
-      tabcontent[i].style.display = "none";
-    }
-
-    // Get all elements with class="tablinks" and remove the class "active"
-    tablinks = document.getElementsByClassName("tablinks");
-    for (i = 0; i < tablinks.length; i++) {
-      tablinks[i].className = tablinks[i].className.replace(" active", "");
-    }
-
-    // Show the current tab, and add an "active" class to the button that opened the tab
-    document.getElementById(ghaName).style.display = "block";
-    evt.currentTarget.className += " active";
-  }
-
-  document.getElementById("defaultOpen").click();
 </script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
   - changelog.md
 
 markdown_extensions:
+  - md_in_html
   - fenced_code
   - toc:
       permalink: True

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,13 +26,16 @@ nav:
 
 markdown_extensions:
   - md_in_html
-  - fenced_code
   - toc:
       permalink: True
   - attr_list
   - admonition
   - pymdownx.magiclink:
       repo_url_shortener: True
+  - pymdownx.highlight:
+      # use highlightjs - it's built-in to the theme
+      use_pygments: False
+  - pymdownx.superfences
 
 plugins:
   - include-markdown

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 extras = {
     "docs": [
-        "mkdocs-include-markdown-plugin==2.1.1",
+        "mkdocs-include-markdown-plugin==2.7.2",
         "mkdocs==1.0.4",
         "pymdown-extensions",
     ],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 extras = {
     "docs": [
-        "mkdocs-include-markdown-plugin==2.7.2",
+        "mkdocs-include-markdown-plugin==2.8.0",
         "mkdocs==1.0.4",
         "pymdown-extensions",
     ],


### PR DESCRIPTION
This is a rough draft example of what tabs would look like. I've applied it to one place (GHA example), and the implementation is highly manual and not reusable, so will need to be improved if we want to go this way (@joerick might be able to be a lot more elegant at this than me :), or maybe there's a built-in tool somewhere (though I think we would need to support super fences, which we don't yet). Previously mentioned here: https://github.com/joerick/cibuildwheel/pull/567#issuecomment-770572043

Thoughts? [Visit the RtD PR check to view the docs, setup page](https://cibuildwheel--576.org.readthedocs.build/en/576/setup/). I've recently added tabs here: https://packaging.python.org/tutorials/packaging-projects/#configuring-metadata (though that was in sphinx).