### PR TITLE
fix: add a blank line for better visual spacing

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -282,7 +282,7 @@ def main() -> None:
     if not output_dir.exists():
         output_dir.mkdir(parents=True)
 
-    with cibuildwheel.util.print_new_wheels("{n} wheels produced in {m:.0f} minutes:", output_dir):
+    with cibuildwheel.util.print_new_wheels("\n{n} wheels produced in {m:.0f} minutes:", output_dir):
         if platform == 'linux':
             cibuildwheel.linux.build(build_options)
         elif platform == 'windows':


### PR DESCRIPTION
Adding a blank line before the printout from #570; the new printout is fantastic and useful, but a little crowded onto the other printouts, which all have a blank line spacing.
