### PR TITLE
docs: fix bullets in 1.6.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ _9 September 2020_
   [still on Python 3.9b3](https://github.com/pypa/manylinux/issues/758), not a
   release candidate. We'd advise holding off on distributing 3.9 ppc64le wheels
   until a subsequent version of cibuildwheel.
-  
+
 - 🌟 Add Gitlab CI support. Gitlab CI can now build Linux wheels, using
   cibuildwheel. (#419)
 - 🐛 Fix a bug that causes pyproject.toml dependencies to fail to install on

--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ _9 September 2020_
   [still on Python 3.9b3](https://github.com/pypa/manylinux/issues/758), not a
   release candidate. We'd advise holding off on distributing 3.9 ppc64le wheels
   until a subsequent version of cibuildwheel.
+  
 - 🌟 Add Gitlab CI support. Gitlab CI can now build Linux wheels, using
   cibuildwheel. (#419)
 - 🐛 Fix a bug that causes pyproject.toml dependencies to fail to install on


### PR DESCRIPTION
These were not rendering correctly:

<img width="738" alt="Screen Shot 2021-02-06 at 8 49 50 PM" src="https://user-images.githubusercontent.com/4616906/107134131-3d362b80-68bd-11eb-8624-b63d221568f1.png">
