### PR TITLE
fix: set MACOSX_DEPLOYMENT_TARGET for BEFORE_ALL

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -288,6 +288,7 @@ def build(options: BuildOptions) -> None:
         if options.before_all:
             log.step('Running before_all...')
             env = options.environment.as_dictionary(prev_environment=os.environ)
+            env.setdefault('MACOSX_DEPLOYMENT_TARGET', '10.9')
             before_all_prepared = prepare_command(options.before_all, project='.', package=options.package_dir)
             call([before_all_prepared], shell=True, env=env)
 


### PR DESCRIPTION
Looking at it, I think just a simple fix is likely okay; there's not a way to combine these easily, and it's a bit specific to this one variable. Fixes #563.
