### PR TITLE
tests: don't expect CPython 2.7 in manylinux2010 images

### DIFF
--- a/test/test_docker_images.py
+++ b/test/test_docker_images.py
@@ -31,10 +31,10 @@ def test(tmp_path):
     actual_wheels = utils.cibuildwheel_run(project_dir, add_env={
         'CIBW_MANYLINUX_X86_64_IMAGE': 'dockcross/manylinux2010-x64',
         'CIBW_MANYLINUX_I686_IMAGE': 'dockcross/manylinux2010-x86',
-        'CIBW_SKIP': 'pp* cp39-*',
+        'CIBW_SKIP': 'pp* cp27-* cp39-*',
     })
 
     # also check that we got the right wheels built
     expected_wheels = [w for w in utils.expected_wheels('spam', '0.1.0')
-                       if '-pp' not in w and '-cp39-' not in w]
+                       if '-pp' not in w and '-cp39-' not in w and '-cp27-' not in w]
     assert set(actual_wheels) == set(expected_wheels)


### PR DESCRIPTION
Fixing our tests, stage 1. Stage 2 will be when we update our docker images. We might want to pin to the last manylinux2010 with Python2 for the cibuildwheel 1.9.x series. The next release could drop Python 2 when building with manylinux2010, just like 2014 does now, I believe.
