### PR TITLE
refactor: string and setup.cfg normalization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@ repos:
   - id: check-case-conflict
   - id: check-merge-conflict
   - id: check-yaml
+  - id: check-toml
+  - id: debug-statements
   - id: end-of-file-fixer
     exclude: (cibuildwheel/resources/pinned_docker_images.cfg)|(.svg$)
   - id: mixed-line-ending
@@ -21,6 +23,12 @@ repos:
   hooks:
   - id: black
     files: ^bin/update_pythons.py|setup.py$
+
+- repo: https://github.com/asottile/setup-cfg-fmt
+  rev: v1.16.0
+  hooks:
+  - id: setup-cfg-fmt
+    stages: [manual]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.812
@@ -54,8 +62,6 @@ repos:
     exclude: cibuildwheel/resources/
     additional_dependencies: [flake8-bugbear]
 
-
-# The original pybind11 checks for a few C++ style items
 - repo: local
   hooks:
   - id: disallow-caps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,5 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
-target-version = ['py36']
+target-version = ['py36', 'py37', 'py38']
+skip-string-normalization = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,39 +1,48 @@
 [metadata]
-
 name = cibuildwheel
 version = 1.10.0
 description = Build Python wheels on CI with minimal configuration.
 long_description = file: README.md
 long_description_content_type = text/markdown
+url = https://github.com/joerick/cibuildwheel
 author = Joe Rickerby
 author_email = joerick@mac.com
-url = https://github.com/joerick/cibuildwheel
 license = BSD
+license_file = LICENSE
 classifiers =
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Development Status :: 5 - Production/Stable
-    License :: OSI Approved :: BSD License
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Build Tools
+keywords = ci,wheel,packaging,pypi,travis,appveyor,macos,linux,windows
 project_urls =
     Changelog=https://github.com/joerick/cibuildwheel#changelog
     Documentation=https://cibuildwheel.readthedocs.io/
-keywords = ci,wheel,packaging,pypi,travis,appveyor,macos,linux,windows
 
 [options]
 packages = find:
-zip_safe = False
-include_package_data = True
-python_requires = >=3.6
 install_requires =
     bashlex!=0.13
-    toml
-    certifi
     bracex
+    certifi
     packaging
-    typing_extensions; python_version < '3.8'
+    toml
+    typing_extensions;python_version < '3.8'
+python_requires = >=3.6
+include_package_data = True
+zip_safe = False
+
+[options.entry_points]
+console_scripts =
+    cibuildwheel = cibuildwheel.__main__:main
 
 [options.package_data]
 cibuildwheel = resources/*
@@ -42,28 +51,23 @@ cibuildwheel = resources/*
 include =
     cibuildwheel
 
-[options.entry_points]
-console_scripts =
-    cibuildwheel = cibuildwheel.__main__:main
-
-
 [flake8]
 ignore = E501,W503,E741,E226,B950
 select = C,E,F,W,B,B9
 application-import-names = cibuildwheel
 exclude =
-  cibuildwheel/resources/,
-  dist/,
-  build/,
-  .git/,
-  env/,
-  env2/,
-  env??/,
-  .venv/,
-  site/
+    cibuildwheel/resources/,
+    dist/,
+    build/,
+    .git/,
+    env/,
+    env2/,
+    env??/,
+    .venv/,
+    site/
 
 [tool:pytest]
-junit_family=xunit2
+junit_family = xunit2
 testpaths =
     test
     unit_test
@@ -113,5 +117,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [tool:isort]
-profile=black
-multi_line_output=3
+profile = black
+multi_line_output = 3


### PR DESCRIPTION
I found (from pypa/build) a way to enforce blackwards quotes (single quotes instead of double quotes). Black's argument (in English, single quotes are more common, so using double quotes avoids escaping as often) is reasonable, though I really just like a standard regardless of which one, and black is reasonable. But if we are going with single quotes (for now?), let's be consistent. (And it's mostly my fault that we are not, I think, because I revert to blackish).

Also adding a few extra pre-commit checks, and _almost_ applying consistent styling in pre-commit to setup.cfg - the parser loses comments, so can't activate it as as default check.

Look at the changes by commit for easier review.