### PR TITLE
Pin `manylinux2010` images (CPython 2.7 support)

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -23,7 +23,7 @@ jobs:
     - name: "Run update: python configs"
       run: python ./bin/update_pythons.py --force
     - name: Create Pull Request
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == 'joerick/cibuildwheel'
       uses: peter-evans/create-pull-request@v3
       with:
         commit-message: Update dependencies

--- a/bin/update_dependencies.py
+++ b/bin/update_dependencies.py
@@ -53,28 +53,34 @@ Image = namedtuple('Image', [
     'manylinux_version',
     'platform',
     'image_name',
+    'tag',
 ])
 
 images = [
-    Image('manylinux1', 'x86_64', 'quay.io/pypa/manylinux1_x86_64'),
-    Image('manylinux1', 'i686', 'quay.io/pypa/manylinux1_i686'),
+    Image('manylinux1', 'x86_64', 'quay.io/pypa/manylinux1_x86_64', None),
+    Image('manylinux1', 'i686', 'quay.io/pypa/manylinux1_i686', None),
 
-    Image('manylinux2010', 'x86_64', 'quay.io/pypa/manylinux2010_x86_64'),
-    Image('manylinux2010', 'i686', 'quay.io/pypa/manylinux2010_i686'),
-    Image('manylinux2010', 'pypy_x86_64', 'pypywheels/manylinux2010-pypy_x86_64'),
+    # Images for manylinux2010 are pinned to the latest tag supporting cp27
+    Image('manylinux2010', 'x86_64', 'quay.io/pypa/manylinux2010_x86_64', '2021-02-06-3d322a5'),
+    Image('manylinux2010', 'i686', 'quay.io/pypa/manylinux2010_i686', '2021-02-06-3d322a5'),
 
-    Image('manylinux2014', 'x86_64', 'quay.io/pypa/manylinux2014_x86_64'),
-    Image('manylinux2014', 'i686', 'quay.io/pypa/manylinux2014_i686'),
-    Image('manylinux2014', 'aarch64', 'quay.io/pypa/manylinux2014_aarch64'),
-    Image('manylinux2014', 'ppc64le', 'quay.io/pypa/manylinux2014_ppc64le'),
-    Image('manylinux2014', 's390x', 'quay.io/pypa/manylinux2014_s390x'),
+    Image('manylinux2010', 'pypy_x86_64', 'pypywheels/manylinux2010-pypy_x86_64', None),
+
+    Image('manylinux2014', 'x86_64', 'quay.io/pypa/manylinux2014_x86_64', None),
+    Image('manylinux2014', 'i686', 'quay.io/pypa/manylinux2014_i686', None),
+    Image('manylinux2014', 'aarch64', 'quay.io/pypa/manylinux2014_aarch64', None),
+    Image('manylinux2014', 'ppc64le', 'quay.io/pypa/manylinux2014_ppc64le', None),
+    Image('manylinux2014', 's390x', 'quay.io/pypa/manylinux2014_s390x', None),
 ]
 
 config = configparser.ConfigParser()
 
 for image in images:
     # get the tag name whose digest matches 'latest'
-    if image.image_name.startswith('quay.io/'):
+    if image.tag is not None:
+        # image has been pinned, do not update
+        tag_name = image.tag
+    elif image.image_name.startswith('quay.io/'):
         _, _, repository_name = image.image_name.partition('/')
         response = requests.get(
             f'https://quay.io/api/v1/repository/{repository_name}?includeTags=true'

--- a/bin/update_dependencies.py
+++ b/bin/update_dependencies.py
@@ -28,7 +28,8 @@ if '--no-docker' in sys.argv:
             '--output-file', f'cibuildwheel/resources/constraints-python{python_version}.txt'
         ], check=True)
 else:
-    image_runner = 'quay.io/pypa/manylinux2010_x86_64:latest'
+    # latest manylinux2010 image with cpython 2.7 support
+    image_runner = 'quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5'
     subprocess.run(['docker', 'pull', image_runner], check=True)
     for python_version in PYTHON_VERSIONS:
         abi_flags = '' if int(python_version) >= 38 else 'm'

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,22 +1,22 @@
 [x86_64]
-manylinux1 = quay.io/pypa/manylinux1_x86_64:2021-01-24-153e846
-manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2021-01-24-4117e7c
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2021-01-24-91ce2b8
+manylinux1 = quay.io/pypa/manylinux1_x86_64:2021-02-06-920c3c7
+manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2021-02-14-fc316c3
 
 [i686]
-manylinux1 = quay.io/pypa/manylinux1_i686:2021-01-24-153e846
-manylinux2010 = quay.io/pypa/manylinux2010_i686:2021-01-24-4117e7c
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2021-01-24-91ce2b8
+manylinux1 = quay.io/pypa/manylinux1_i686:2021-02-06-920c3c7
+manylinux2010 = quay.io/pypa/manylinux2010_i686:2021-02-06-3d322a5
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2021-02-14-fc316c3
 
 [pypy_x86_64]
 manylinux2010 = pypywheels/manylinux2010-pypy_x86_64:2020-12-11-f1e0e80
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2021-01-24-91ce2b8
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2021-02-14-fc316c3
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2021-01-24-91ce2b8
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2021-02-14-fc316c3
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2021-01-24-91ce2b8
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2021-02-14-fc316c3
 


### PR DESCRIPTION
`manylinux2010` dropped CPython 2.7
Use the tag `2021-02-06-3d322a5` which is the last supporting CPython 2.7