### PR TITLE
fix: macos11 universal naming corrected

### DIFF
--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -181,7 +181,7 @@ class CPythonVersions:
                 self.versions_dict[version] = uri
 
     def update_version_macos(self, identifier: str, spec: Specifier) -> Optional[ConfigMacOS]:
-        file_idents = ("macos11.0.pkg", "macosx10.9.pkg", "macosx10.6.pkg")
+        file_idents = ("macos11.pkg", "macosx10.9.pkg", "macosx10.6.pkg")
         sorted_versions = sorted(v for v in self.versions_dict if spec.contains(v))
 
         for version in reversed(sorted_versions):


### PR DESCRIPTION
Should fix the update script (as seen in #610)