### PR TITLE
Make GHA pre-commit check a precursor to main test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,17 @@ on:
     # allow manual runs on branches without a PR
 
 jobs:
+  pre-commit:
+    name: Pre-commit checks (mypy, flake8, etc.)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0
+
   test:
     name: Test cibuildwheel on ${{ matrix.os }}
+    needs: pre-commit
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -62,6 +71,7 @@ jobs:
 
   test-emulated:
     name: Test emulated cibuildwheel using qemu
+    needs: pre-commit
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,6 @@ on:
     # allow manual runs on branches without a PR
 
 jobs:
-  pre-commit:
-    name: Pre-commit checks (mypy, flake8, etc.)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
-
   test:
     name: Test cibuildwheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This check was the same as the check performed by pre-commit.ci, except that the pre-commit.ci is a bit faster and can fix some issues itself, so I'm removing the GHA one in favour of the pre-commit.ci one.