### PR TITLE
ci: fix choco usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,6 @@ jobs:
       run: |
         python -m pip install -e ".[dev]"
 
-    - name: Install Visual C++ for Python 2.7
-      if: runner.os == 'Windows'
-      run: |
-        choco upgrade vcpython27 -y
-
     - name: Get PR labels
       id: pr-labels
       uses: joerick/pr-labels-action@v1.0.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install Visual C++ for Python 2.7
       if: runner.os == 'Windows'
       run: |
-        choco install vcpython27 -f -y
+        choco upgrade vcpython27 -y
 
     - name: Get PR labels
       id: pr-labels

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ jobs:
       os: windows
       language: shell
       before_install:
-       - choco install python3 --version 3.6.8 --no-progress -y
-       # Update root certificates to fix SSL error; see http://www.chawn.com/RootCerts.htm
-       - powershell "md C:\temp\certs; CertUtil -generateSSTFromWU C:\temp\certs\RootStore.sst; Get-ChildItem -Path C:\\temp\certs\Rootstore.sst | Import-Certificate -CertStoreLocation Cert:\\LocalMachine\\Root\\ | out-null"
+        - choco upgrade python3 -y --version 3.6.8 --limit-output
+        # Update root certificates to fix SSL error; see http://www.chawn.com/RootCerts.htm
+        - powershell "md C:\temp\certs; CertUtil -generateSSTFromWU C:\temp\certs\RootStore.sst; Get-ChildItem -Path C:\\temp\certs\Rootstore.sst | Import-Certificate -CertStoreLocation Cert:\\LocalMachine\\Root\\ | out-null"
       env:
         - PYTHON=C:\\Python36\\python
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ What does it do?
 | PyPy 3.6 v7.3.3 | ✅ |    |    | ✅  | ✅ |    |    |    |   |
 | PyPy 3.7 (beta) v7.3.3 | ✅ | |  | ✅  | ✅ |    |    |   |    |
 
-<sup>¹ Not supported on Travis</sup><br>
+<sup>¹ Only using a workaround with a newer compiler; Microsoft removed the 2008 compiler for Python 2.7 in April 2021.</sup><br>
 
 - Builds manylinux, macOS 10.9+, and Windows wheels for CPython and PyPy
 - Works on GitHub Actions, Azure Pipelines, Travis CI, AppVeyor, CircleCI, and GitLab CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,8 +26,6 @@ jobs:
     - task: UsePythonVersion@0
       inputs:
         versionSpec: '3.6'
-    - script: choco upgrade vcpython27 -y
-      displayName: Install Visual C++ for Python 2.7
     - bash: |
         python -m pip install -e ".[dev]" pytest-azurepipelines
         python ./bin/run_tests.py
@@ -39,8 +37,6 @@ jobs:
     - task: UsePythonVersion@0
       inputs:
         versionSpec: '3.8'
-    - script: choco upgrade vcpython27 -y
-      displayName: Install Visual C++ for Python 2.7
     - bash: |
         python -m pip install -e ".[dev]" pytest-azurepipelines
         python ./bin/run_tests.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
     - task: UsePythonVersion@0
       inputs:
         versionSpec: '3.6'
-    - script: choco install vcpython27 -f -y
+    - script: choco upgrade vcpython27 -y
       displayName: Install Visual C++ for Python 2.7
     - bash: |
         python -m pip install -e ".[dev]" pytest-azurepipelines
@@ -39,7 +39,7 @@ jobs:
     - task: UsePythonVersion@0
       inputs:
         versionSpec: '3.8'
-    - script: choco install vcpython27 -f -y
+    - script: choco upgrade vcpython27 -y
       displayName: Install Visual C++ for Python 2.7
     - bash: |
         python -m pip install -e ".[dev]" pytest-azurepipelines

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -25,7 +25,6 @@ from .util import (
 )
 
 IS_RUNNING_ON_AZURE = Path('C:\\hostedtoolcache').exists()
-IS_RUNNING_ON_TRAVIS = os.environ.get('TRAVIS_OS_NAME') == 'windows'
 
 
 def call(args: Sequence[PathOrStr], env: Optional[Dict[str, str]] = None,
@@ -69,10 +68,9 @@ def get_python_configurations(
         '64': Architecture.AMD64,
     }
 
+    # Only supported with custom compiler, since MS removed the 2008 compiler download
     custom_compiler = os.environ.get('DISTUTILS_USE_SDK') and os.environ.get('MSSdk')
-    if IS_RUNNING_ON_TRAVIS and not custom_compiler:
-        # cannot install VCForPython27.msi which is needed for compiling C software
-        # try with (and similar): msiexec /i VCForPython27.msi ALLUSERS=1 ACCEPT=YES /passive
+    if not custom_compiler:
         python_configurations = [c for c in python_configurations if not c.version.startswith('2.7')]
 
     # skip builds as required

--- a/docs/cpp_standards.md
+++ b/docs/cpp_standards.md
@@ -30,9 +30,9 @@ For more details see https://en.cppreference.com/w/cpp/compiler_support, https:/
 
 ## Windows and Python 2.7
 
-Visual C++ for Python 2.7 does not support modern C++ standards (i.e., C++11 and later). When building on Appveyor, you will need to either use the "Visual Studio 2017" or "Visual Studio 2019" image, but Python 2.7 is not supported on these images - skip it by setting `CIBW_SKIP=cp27-win*`.
+Visual C++ for Python 2.7 does not support modern C++ standards (i.e., C++11 and later), and Microsoft has removed the download for the required Visual Studio 2008 needed to build a native extension in April, 2021.
 
-There is an optional workaround for this, though: the pybind11 project argues and shows that it is [possible to compile Python 2.7 extension with a newer compiler](https://pybind11.readthedocs.io/en/stable/faq.html#working-with-ancient-visual-studio-2008-builds-on-windows) and has an example project showing how to do this: https://github.com/pybind/python_example. The main catch is that a user might need to install [a newer "Microsoft Visual C++ Redistributable"](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads), since the newer C++ standard library's binaries are not included by default with the Python 2.7 installation.
+There is an optional workaround, though: the pybind11 project argues and shows that it is [possible to compile Python 2.7 extension with a newer compiler](https://pybind11.readthedocs.io/en/stable/faq.html#working-with-ancient-visual-studio-2008-builds-on-windows) and has an example project showing how to do this: https://github.com/pybind/python_example. The main catch is that a user might need to install [a newer "Microsoft Visual C++ Redistributable"](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads), since the newer C++ standard library's binaries are not included by default with the Python 2.7 installation.
 
 Forcing `distutils` or `setuptools` to use a more recent version of MSVC that supports modern C++ can be done in the following way:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -47,7 +47,7 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
 
           - name: Install Visual C++ for Python 2.7
             if: runner.os == 'Windows'
-            run: choco install vcpython27 -f -y
+            run: choco upgrade vcpython27 -y
 
           - name: Build wheels
             run: pipx run cibuildwheel==1.10.0
@@ -89,7 +89,7 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
 
           - name: Install Visual C++ for Python 2.7
             if: runner.os == 'Windows'
-            run: choco install vcpython27 -f -y
+            run: choco upgrade vcpython27 -y
 
           - name: Build wheels
             run: python -m cibuildwheel --output-dir wheelhouse

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -45,10 +45,6 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
         steps:
           - uses: actions/checkout@v2
 
-          - name: Install Visual C++ for Python 2.7
-            if: runner.os == 'Windows'
-            run: choco upgrade vcpython27 -y
-
           - name: Build wheels
             run: pipx run cibuildwheel==1.10.0
 
@@ -86,10 +82,6 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
 
           - name: Install cibuildwheel
             run: python -m pip install cibuildwheel==1.10.0
-
-          - name: Install Visual C++ for Python 2.7
-            if: runner.os == 'Windows'
-            run: choco upgrade vcpython27 -y
 
           - name: Build wheels
             run: python -m cibuildwheel --output-dir wheelhouse

--- a/examples/azure-pipelines-minimal.yml
+++ b/examples/azure-pipelines-minimal.yml
@@ -31,7 +31,7 @@ jobs:
   pool: {vmImage: 'vs2017-win2016'}
   steps:
     - task: UsePythonVersion@0
-    - script: choco install vcpython27 -f -y
+    - script: choco upgrade vcpython27 -y
       displayName: Install Visual C++ for Python 2.7
     - bash: |
         set -o errexit

--- a/examples/azure-pipelines-minimal.yml
+++ b/examples/azure-pipelines-minimal.yml
@@ -31,8 +31,6 @@ jobs:
   pool: {vmImage: 'vs2017-win2016'}
   steps:
     - task: UsePythonVersion@0
-    - script: choco upgrade vcpython27 -y
-      displayName: Install Visual C++ for Python 2.7
     - bash: |
         set -o errexit
         python -m pip install --upgrade pip

--- a/examples/github-deploy.yml
+++ b/examples/github-deploy.yml
@@ -26,10 +26,6 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Install Visual C++ for Python 2.7
-        if: runner.os == 'Windows'
-        run: choco upgrade vcpython27 -y
-
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.10.0
 

--- a/examples/github-deploy.yml
+++ b/examples/github-deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Visual C++ for Python 2.7
         if: runner.os == 'Windows'
-        run: choco install vcpython27 -f -y
+        run: choco upgrade vcpython27 -y
 
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.10.0

--- a/examples/github-minimal.yml
+++ b/examples/github-minimal.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Visual C++ for Python 2.7
-        if: runner.os == 'Windows'
-        run: choco upgrade vcpython27 -y
-
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.10.0
         # to supply options, put them in 'env', like:

--- a/examples/github-minimal.yml
+++ b/examples/github-minimal.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install Visual C++ for Python 2.7
         if: runner.os == 'Windows'
-        run: choco install vcpython27 -f -y
+        run: choco upgrade vcpython27 -y
 
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.10.0

--- a/examples/github-with-qemu.yml
+++ b/examples/github-with-qemu.yml
@@ -18,10 +18,6 @@ jobs:
         with:
           python-version: '3.7'
 
-      - name: Install Visual C++ for Python 2.7
-        if: runner.os == 'Windows'
-        run: choco upgrade vcpython27 -y
-
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v1

--- a/examples/github-with-qemu.yml
+++ b/examples/github-with-qemu.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Visual C++ for Python 2.7
         if: runner.os == 'Windows'
-        run: choco install vcpython27 -f -y
+        run: choco upgrade vcpython27 -y
 
       - name: Set up QEMU
         if: runner.os == 'Linux'

--- a/examples/travis-ci-deploy.yml
+++ b/examples/travis-ci-deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - os: windows
       language: shell
       before_install:
-        - choco install python --version 3.8.6
+        - choco upgrade python -y --version 3.8.6
         - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
         # make sure it's on PATH as 'python3'
         - ln -s /c/Python38/python.exe /c/Python38/python3.exe

--- a/examples/travis-ci-minimal.yml
+++ b/examples/travis-ci-minimal.yml
@@ -20,7 +20,7 @@ jobs:
     - os: windows
       language: shell
       before_install:
-        - choco install python --version 3.8.6
+        - choco upgrade python -y --version 3.8.6
         - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
         # make sure it's on PATH as 'python3'
         - ln -s /c/Python38/python.exe /c/Python38/python3.exe

--- a/examples/travis-ci-test-and-deploy.yml
+++ b/examples/travis-ci-test-and-deploy.yml
@@ -14,7 +14,7 @@ python:
 before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" = windows ]]; then
-        choco install python --version 3.8.6
+        choco upgrade python -y --version 3.8.6
         export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
         # make sure it's on PATH as 'python3'
         ln -s /c/Python38/python.exe /c/Python38/python3.exe

--- a/test/test_dependency_versions.py
+++ b/test/test_dependency_versions.py
@@ -51,8 +51,8 @@ def test_pinned_versions(tmp_path, python_version):
     if utils.platform == 'linux':
         pytest.skip('linux doesn\'t pin individual tool versions, it pins manylinux images instead')
 
-    if utils.IS_WINDOWS_RUNNING_ON_TRAVIS and python_version == '2.7':
-        pytest.skip('Windows + Travis CI requires a workaround')
+    if utils.platform == 'windows' and python_version == '2.7':
+        pytest.skip('Windows requires a workaround')
 
     is_running_on_macos_11_or_later = (
         utils.platform == 'macos' and utils.get_macos_version() >= (10, 16)
@@ -123,7 +123,7 @@ def test_dependency_constraints_file(tmp_path, python_version):
     if utils.platform == 'linux':
         pytest.skip('linux doesn\'t pin individual tool versions, it pins manylinux images instead')
 
-    if utils.IS_WINDOWS_RUNNING_ON_TRAVIS and python_version == '2.7':
+    if utils.platform == 'windows' and python_version == '2.7':
         pytest.skip('Windows + Travis CI requires a workaround')
 
     project_dir = tmp_path / 'project'

--- a/test/utils.py
+++ b/test/utils.py
@@ -12,7 +12,18 @@ import sys
 from contextlib import contextmanager
 from tempfile import mkdtemp
 
-IS_WINDOWS_RUNNING_ON_TRAVIS = os.environ.get('TRAVIS_OS_NAME') == 'windows'
+platform: str
+
+if 'CIBW_PLATFORM' in os.environ:
+    platform = os.environ['CIBW_PLATFORM']
+elif sys.platform.startswith('linux'):
+    platform = 'linux'
+elif sys.platform.startswith('darwin'):
+    platform = 'macos'
+elif sys.platform in ['win32', 'cygwin']:
+    platform = 'windows'
+else:
+    raise Exception('Unsupported platform')
 
 
 # Python 2 does not have a tempfile.TemporaryDirectory context manager
@@ -91,7 +102,7 @@ def _get_arm64_macosx_deployment_target(macosx_deployment_target: str) -> str:
 
 def expected_wheels(package_name, package_version, manylinux_versions=None,
                     macosx_deployment_target='10.9', machine_arch=None, *,
-                    exclude_27=IS_WINDOWS_RUNNING_ON_TRAVIS):
+                    exclude_27=platform == 'windows'):
     '''
     Returns a list of expected wheels from a run of cibuildwheel.
     '''
@@ -187,17 +198,3 @@ def get_macos_version():
     '''
     version_str, _, _ = pm.mac_ver()
     return tuple(map(int, version_str.split(".")[:2]))
-
-
-platform = None
-
-if 'CIBW_PLATFORM' in os.environ:
-    platform = os.environ['CIBW_PLATFORM']
-elif sys.platform.startswith('linux'):
-    platform = 'linux'
-elif sys.platform.startswith('darwin'):
-    platform = 'macos'
-elif sys.platform in ['win32', 'cygwin']:
-    platform = 'windows'
-else:
-    raise Exception('Unsupported platform')


### PR DESCRIPTION
Hoping to fix the issues seen in current CI runs. At the very least, we will follow the style guide linked below.

Following https://docs.chocolatey.org/en-us/choco/commands/#scripting-integration-best-practices-style-guide

* Avoid `-f` in scripts
* Always use `-y` in scripts
* Use `upgrade` instead of `install` in scripts
* Use `--limit-output` for more parsable output (should turn off progress bar as well, hopefully)

The issue with vcpython27 might be temporary, caused by the -f, or possibly permanent since it has been untouched since 2016.
