### PR TITLE
Fix nuget error on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,4 @@ jobs:
 
 install: $PYTHON -m pip install -e ".[dev]" pytest-custom-exit-code
 
-script: |
-  $PYTHON -c "import os, pprint; pprint.pprint(os.environ)"
-  $PYTHON -c "import os; config_path = os.environ['APPDATA']+'/NuGet/NuGet.Config'; print(open(config_path).read())"
-  ls $APPDATA
-  ls $APPDATA\NuGet
-  $PYTHON ./bin/run_tests.py
+script: $PYTHON ./bin/run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install: $PYTHON -m pip install -e ".[dev]" pytest-custom-exit-code
 
 script: |
   $PYTHON -c "import os, pprint; pprint.pprint(os.environ)"
-  $PYTHON -c "import os; config_path = os.environ['APPDATA']+'\NuGet\NuGet.Config'; print(open(config_path).read())"
-  dir %AppData%
-  dir %AppData%\NuGet
+  $PYTHON -c "import os; config_path = os.environ['APPDATA']+'\\NuGet\\NuGet.Config'; print(open(config_path).read())"
+  ls $AppData
+  ls $AppData\NuGet
   $PYTHON ./bin/run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ jobs:
 install: $PYTHON -m pip install -e ".[dev]" pytest-custom-exit-code
 
 script: |
-  $PYTHON -c "import os; print(os.environ)"
-  nuget sources list
-  nuget config
+  $PYTHON -c "import os, pprint; pprint.pprint(os.environ)"
+  $PYTHON -c "import os; config_path = os.environ['APPDATA']+'\NuGet\NuGet.Config'; print(open(config_path).read())"
+  dir %AppData%
+  dir %AppData%\NuGet
   $PYTHON ./bin/run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,8 @@ jobs:
 
 install: $PYTHON -m pip install -e ".[dev]" pytest-custom-exit-code
 
-script: $PYTHON ./bin/run_tests.py
+script: |
+  $PYTHON -c "import os; print(os.environ)"
+  nuget sources list
+  nuget config
+  $PYTHON ./bin/run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install: $PYTHON -m pip install -e ".[dev]" pytest-custom-exit-code
 
 script: |
   $PYTHON -c "import os, pprint; pprint.pprint(os.environ)"
-  $PYTHON -c "import os; config_path = os.environ['APPDATA']+'\\NuGet\\NuGet.Config'; print(open(config_path).read())"
-  ls $AppData
-  ls $AppData\NuGet
+  $PYTHON -c "import os; config_path = os.environ['APPDATA']+'/NuGet/NuGet.Config'; print(open(config_path).read())"
+  ls $APPDATA
+  ls $APPDATA\NuGet
   $PYTHON ./bin/run_tests.py

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -47,8 +47,8 @@ def get_nuget_args(version: str, arch: str) -> List[str]:
     return [
         python_name,
         '-Version', version,
-        '-OutputDirectory', 'C:\\cibw\\python',
         '-FallbackSource', 'https://api.nuget.org/v3/index.json',
+        '-OutputDirectory', 'C:\\cibw\\python',
     ]
 
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -44,7 +44,12 @@ def get_nuget_args(version: str, arch: str) -> List[str]:
     python_name = 'python' if version[0] == '3' else 'python2'
     if arch == '32':
         python_name += 'x86'
-    return [python_name, '-Version', version, '-OutputDirectory', 'C:\\cibw\\python']
+    return [
+        python_name,
+        '-Version', version,
+        '-OutputDirectory', 'C:\\cibw\\python',
+        '-FallbackSource', 'https://api.nuget.org/v3/index.json',
+    ]
 
 
 class PythonConfiguration(NamedTuple):


### PR DESCRIPTION
Fix this error on Travis:

> Package 'pythonx86 3.5.4' is not found in the following primary source(s): 'C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\'. Please verify all your online package sources are available (OR) package id, version are specified correctly

The problem seems to be that Travis added a blank nuget config file at `%AppData%\NuGet\NuGet.Config`, so nuget didn't know where to fetch its packages from. This PR adds a `FallbackSource` via the command line, so regardless of config files, nuget can find the registry.