### PR TITLE
ci: use native actions syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,8 @@ jobs:
       run: |
         python -m pip install -e ".[dev]"
 
-    - name: Get PR labels
-      id: pr-labels
-      uses: joerick/pr-labels-action@v1.0.6
-
     - name: Sample build
-      if: contains(steps.pr-labels.outputs.labels, ' ci-sample-build ')
+      if: "contains(github.event.pull_request.labels.*.name, 'CI: Sample build')"
       run: |
         python bin/sample_build.py
 


### PR DESCRIPTION
I think the custom action predates the native syntax? Besides removing a requirement, this also should get around the "snapshot" issue seen in #541; the native syntax should allow you to add the label and retrigger the build, while the custom action doesn't let you retrigger with new labels.
