### PR TITLE
[1.x] chore: bump to final Python 3.5 pin

### DIFF
--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,27 +1,27 @@
 [x86_64]
 manylinux1 = quay.io/pypa/manylinux1_x86_64:2021-04-05-14df3a6
 manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2021-05-05-1ac6ef3
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2021-05-05-1ac6ef3
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2021-05-01-28d233a
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2021-05-01-28d233a
 
 [i686]
 manylinux1 = quay.io/pypa/manylinux1_i686:2021-04-05-14df3a6
 manylinux2010 = quay.io/pypa/manylinux2010_i686:2021-02-06-3d322a5
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2021-02-06-3d322a5
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2021-02-06-3d322a5
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2021-05-01-28d233a
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2021-05-01-28d233a
 
 [pypy_x86_64]
 manylinux2010 = pypywheels/manylinux2010-pypy_x86_64:2020-12-11-f1e0e80
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2021-02-06-3d322a5
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2021-02-06-3d322a5
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2021-05-01-28d233a
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2021-05-01-28d233a
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2021-02-06-3d322a5
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_ppc64le:2021-02-06-3d322a5
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2021-05-01-28d233a
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_ppc64le:2021-05-01-28d233a
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2021-02-06-3d322a5
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_s390x:2021-02-06-3d322a5
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2021-05-01-28d233a
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_s390x:2021-05-01-28d233a
 

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,27 +1,27 @@
 [x86_64]
 manylinux1 = quay.io/pypa/manylinux1_x86_64:2021-04-05-14df3a6
 manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2021-04-05-b4fd19d
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2021-04-05-b4fd19d
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2021-05-05-1ac6ef3
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2021-05-05-1ac6ef3
 
 [i686]
 manylinux1 = quay.io/pypa/manylinux1_i686:2021-04-05-14df3a6
 manylinux2010 = quay.io/pypa/manylinux2010_i686:2021-02-06-3d322a5
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2021-04-05-b4fd19d
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2021-04-05-b4fd19d
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2021-02-06-3d322a5
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2021-02-06-3d322a5
 
 [pypy_x86_64]
 manylinux2010 = pypywheels/manylinux2010-pypy_x86_64:2020-12-11-f1e0e80
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2021-04-05-b4fd19d
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2021-04-05-b4fd19d
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2021-02-06-3d322a5
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2021-02-06-3d322a5
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2021-04-05-b4fd19d
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_ppc64le:2021-04-05-b4fd19d
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2021-02-06-3d322a5
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_ppc64le:2021-02-06-3d322a5
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2021-04-05-b4fd19d
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_s390x:2021-04-05-b4fd19d
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2021-02-06-3d322a5
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_s390x:2021-02-06-3d322a5
 

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,11 +1,11 @@
 [x86_64]
-manylinux1 = quay.io/pypa/manylinux1_x86_64:2021-04-05-14df3a6
+manylinux1 = quay.io/pypa/manylinux1_x86_64:2021-05-05-b64d921
 manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5
 manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2021-05-01-28d233a
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2021-05-01-28d233a
 
 [i686]
-manylinux1 = quay.io/pypa/manylinux1_i686:2021-04-05-14df3a6
+manylinux1 = quay.io/pypa/manylinux1_i686:2021-05-05-b64d921
 manylinux2010 = quay.io/pypa/manylinux2010_i686:2021-02-06-3d322a5
 manylinux2014 = quay.io/pypa/manylinux2014_i686:2021-05-01-28d233a
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2021-05-01-28d233a
@@ -24,4 +24,3 @@ manylinux_2_24 = quay.io/pypa/manylinux_2_24_ppc64le:2021-05-01-28d233a
 [s390x]
 manylinux2014 = quay.io/pypa/manylinux2014_s390x:2021-05-01-28d233a
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_s390x:2021-05-01-28d233a
-


### PR DESCRIPTION
Using the final 3.5 pinned images as mentioned by @mayeut.